### PR TITLE
Add role management CRUD with bootstrap-role protection

### DIFF
--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
@@ -1,0 +1,223 @@
+using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
+{
+    [Area("Admin")]
+    [Authorize(Roles = "Admin")]
+    [AutoValidateAntiforgeryToken]
+    public class RolesController : Controller
+    {
+        private readonly RoleManager<IdentityRole> roleManager;
+        private readonly UserManager<ApplicationUser> userManager;
+        private readonly AdminBootstrapOptions bootstrapOptions;
+
+        public RolesController(
+            RoleManager<IdentityRole> roleManager,
+            UserManager<ApplicationUser> userManager,
+            IOptions<AdminBootstrapOptions> bootstrapOptions)
+        {
+            this.roleManager = roleManager;
+            this.userManager = userManager;
+            this.bootstrapOptions = bootstrapOptions.Value;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var roles = roleManager.Roles.ToList();
+            var items = new List<RoleListItemViewModel>();
+
+            foreach (var role in roles)
+            {
+                var usersInRole = await userManager.GetUsersInRoleAsync(role.Name ?? string.Empty);
+                items.Add(new RoleListItemViewModel
+                {
+                    Id = role.Id,
+                    Name = role.Name ?? string.Empty,
+                    UserCount = usersInRole.Count,
+                    IsProtected = IsProtectedRole(role.Name)
+                });
+            }
+
+            return View(items);
+        }
+
+        [HttpGet]
+        public IActionResult Create()
+        {
+            return View(new CreateRoleViewModel());
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create(CreateRoleViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            if (await roleManager.RoleExistsAsync(model.Name))
+            {
+                ModelState.AddModelError(nameof(model.Name), $"A role named '{model.Name}' already exists.");
+                return View(model);
+            }
+
+            var result = await roleManager.CreateAsync(new IdentityRole(model.Name));
+            if (!result.Succeeded)
+            {
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                return View(model);
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Edit(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return NotFound();
+            }
+
+            var role = await roleManager.FindByIdAsync(id);
+            if (role is null)
+            {
+                return NotFound();
+            }
+
+            var model = new EditRoleViewModel
+            {
+                Id = role.Id,
+                Name = role.Name ?? string.Empty,
+                IsProtected = IsProtectedRole(role.Name)
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Edit(EditRoleViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var role = await roleManager.FindByIdAsync(model.Id);
+            if (role is null)
+            {
+                return NotFound();
+            }
+
+            if (IsProtectedRole(role.Name))
+            {
+                model.IsProtected = true;
+                ModelState.AddModelError(string.Empty, $"The '{role.Name}' role is protected and cannot be renamed.");
+                return View(model);
+            }
+
+            role.Name = model.Name;
+            var result = await roleManager.UpdateAsync(role);
+            if (!result.Succeeded)
+            {
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                return View(model);
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Delete(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return NotFound();
+            }
+
+            var role = await roleManager.FindByIdAsync(id);
+            if (role is null)
+            {
+                return NotFound();
+            }
+
+            var usersInRole = await userManager.GetUsersInRoleAsync(role.Name ?? string.Empty);
+
+            var model = new DeleteRoleViewModel
+            {
+                Id = role.Id,
+                Name = role.Name ?? string.Empty,
+                UserCount = usersInRole.Count,
+                IsProtected = IsProtectedRole(role.Name)
+            };
+
+            return View(model);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        public async Task<IActionResult> DeleteConfirmed(string id)
+        {
+            var role = await roleManager.FindByIdAsync(id);
+            if (role is null)
+            {
+                return NotFound();
+            }
+
+            var usersInRole = await userManager.GetUsersInRoleAsync(role.Name ?? string.Empty);
+
+            var model = new DeleteRoleViewModel
+            {
+                Id = role.Id,
+                Name = role.Name ?? string.Empty,
+                UserCount = usersInRole.Count,
+                IsProtected = IsProtectedRole(role.Name)
+            };
+
+            if (model.IsProtected)
+            {
+                ModelState.AddModelError(string.Empty, $"The '{role.Name}' role is protected and cannot be deleted.");
+                return View(model);
+            }
+
+            if (model.UserCount > 0)
+            {
+                ModelState.AddModelError(string.Empty, $"Cannot delete the '{role.Name}' role because it has {model.UserCount} user(s) assigned.");
+                return View(model);
+            }
+
+            var result = await roleManager.DeleteAsync(role);
+            if (!result.Succeeded)
+            {
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                return View(model);
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool IsProtectedRole(string? roleName)
+        {
+            if (string.IsNullOrEmpty(roleName))
+            {
+                return false;
+            }
+
+            return string.Equals(roleName, bootstrapOptions.RoleName, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
@@ -34,6 +34,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
 
             foreach (var role in roles)
             {
+                // ova pravi N+1 queries. Moze da se optimizira ako e potrebno
                 var usersInRole = await userManager.GetUsersInRoleAsync(role.Name ?? string.Empty);
                 items.Add(new RoleListItemViewModel
                 {
@@ -67,7 +68,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
                 return View(model);
             }
 
-            var result = await roleManager.CreateAsync(new IdentityRole(model.Name));
+            var result = await roleManager.CreateAsync(new IdentityRole(model.Name.Trim()));
             if (!result.Succeeded)
             {
                 foreach (var error in result.Errors)
@@ -125,8 +126,10 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
                 return View(model);
             }
 
-            role.Name = model.Name;
+            role.Name = model.Name.Trim();
             var result = await roleManager.UpdateAsync(role);
+
+            // Pri edit ako imeto e vekje postoecko, RoleManager vrakja username is already taken, nema potreba da se proveruva posebno
             if (!result.Succeeded)
             {
                 foreach (var error in result.Errors)
@@ -210,6 +213,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        // Ako ponatamu e potrebno da se dodade podrshka za povekje zashhtiteni roli moze da se dodade property List<string> ProtectedRoles
         private bool IsProtectedRole(string? roleName)
         {
             if (string.IsNullOrEmpty(roleName))

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/CreateRoleViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/CreateRoleViewModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class CreateRoleViewModel
+    {
+        [Required]
+        [StringLength(64, MinimumLength = 2, ErrorMessage = "The {0} must be between {2} and {1} characters.")]
+        [Display(Name = "Role name")]
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/DeleteRoleViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/DeleteRoleViewModel.cs
@@ -1,0 +1,13 @@
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class DeleteRoleViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+
+        public int UserCount { get; set; }
+
+        public bool IsProtected { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/EditRoleViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/EditRoleViewModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class EditRoleViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(64, MinimumLength = 2, ErrorMessage = "The {0} must be between {2} and {1} characters.")]
+        [Display(Name = "Role name")]
+        public string Name { get; set; } = string.Empty;
+
+        public bool IsProtected { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/RoleListItemViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/RoleListItemViewModel.cs
@@ -1,0 +1,13 @@
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class RoleListItemViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+
+        public int UserCount { get; set; }
+
+        public bool IsProtected { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Create.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Create.cshtml
@@ -1,0 +1,37 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model CreateRoleViewModel
+
+@{
+    ViewData["Title"] = "New role";
+}
+
+<div class="mb-4">
+    <h1 class="h3">New role</h1>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <form asp-area="Admin" asp-controller="Roles" asp-action="Create" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <div class="mb-3">
+                        <label asp-for="Name" class="form-label"></label>
+                        <input asp-for="Name" class="form-control" autofocus />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Create</button>
+                        <a class="btn btn-outline-secondary" asp-area="Admin" asp-controller="Roles" asp-action="Index">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Delete.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Delete.cshtml
@@ -1,0 +1,50 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model DeleteRoleViewModel
+
+@{
+    ViewData["Title"] = "Delete role";
+    var canDelete = !Model.IsProtected && Model.UserCount == 0;
+}
+
+<div class="mb-4">
+    <h1 class="h3">Delete role</h1>
+</div>
+
+@if (Model.IsProtected)
+{
+    <div class="alert alert-warning">
+        This is a protected role and cannot be deleted.
+    </div>
+}
+else if (Model.UserCount > 0)
+{
+    <div class="alert alert-warning">
+        This role has <strong>@Model.UserCount</strong> user(s) assigned and cannot be deleted.
+        Remove all users from the role first.
+    </div>
+}
+
+<div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <p class="mb-1"><strong>Role name:</strong> @Model.Name</p>
+                <p class="mb-1"><strong>Users assigned:</strong> @Model.UserCount</p>
+
+                @if (canDelete)
+                {
+                    <p class="text-muted mt-3">Are you sure you want to delete this role? This action cannot be undone.</p>
+                }
+            </div>
+            <div class="card-footer bg-white">
+                <form asp-area="Admin" asp-controller="Roles" asp-action="Delete" method="post" class="d-inline">
+                    <input type="hidden" name="id" value="@Model.Id" />
+                    <button type="submit" class="btn btn-danger" disabled="@(!canDelete)">Delete</button>
+                </form>
+                <a class="btn btn-outline-secondary" asp-area="Admin" asp-controller="Roles" asp-action="Index">Cancel</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Edit.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Edit.cshtml
@@ -1,0 +1,47 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model EditRoleViewModel
+
+@{
+    ViewData["Title"] = "Edit role";
+}
+
+<div class="mb-4">
+    <h1 class="h3">Edit role</h1>
+</div>
+
+@if (Model.IsProtected)
+{
+    <div class="alert alert-warning">
+        This is a protected role and cannot be renamed.
+    </div>
+}
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <form asp-area="Admin" asp-controller="Roles" asp-action="Edit" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <input type="hidden" asp-for="Id" />
+                    <input type="hidden" asp-for="IsProtected" />
+
+                    <div class="mb-3">
+                        <label asp-for="Name" class="form-label"></label>
+                        <input asp-for="Name" class="form-control" disabled="@Model.IsProtected" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary" disabled="@Model.IsProtected">Save</button>
+                        <a class="btn btn-outline-secondary" asp-area="Admin" asp-controller="Roles" asp-action="Index">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Index.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Roles/Index.cshtml
@@ -1,0 +1,65 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model IEnumerable<RoleListItemViewModel>
+
+@{
+    ViewData["Title"] = "Roles";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3">Roles</h1>
+    <a class="btn btn-primary" asp-area="Admin" asp-controller="Roles" asp-action="Create">
+        New role
+    </a>
+</div>
+
+<div class="card">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0 align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col" class="text-center">Users</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (!Model.Any())
+                {
+                    <tr>
+                        <td colspan="3" class="text-center text-muted py-4">No roles found.</td>
+                    </tr>
+                }
+                else
+                {
+                    foreach (var role in Model)
+                    {
+                        <tr>
+                            <td>
+                                @role.Name
+                                @if (role.IsProtected)
+                                {
+                                    <span class="badge text-bg-secondary ms-2">Protected</span>
+                                }
+                            </td>
+                            <td class="text-center">@role.UserCount</td>
+                            <td class="text-end">
+                                @if (role.IsProtected)
+                                {
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" disabled title="Protected role">Edit</button>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" disabled title="Protected role">Delete</button>
+                                }
+                                else
+                                {
+                                    <a class="btn btn-sm btn-outline-primary"
+                                       asp-area="Admin" asp-controller="Roles" asp-action="Edit" asp-route-id="@role.Id">Edit</a>
+                                    <a class="btn btn-sm btn-outline-danger"
+                                       asp-area="Admin" asp-controller="Roles" asp-action="Delete" asp-route-id="@role.Id">Delete</a>
+                                }
+                            </td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
@@ -38,6 +38,12 @@
                             Dashboard
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Roles" ? "active fw-semibold" : "text-dark")"
+                           asp-area="Admin" asp-controller="Roles" asp-action="Index">
+                            Roles
+                        </a>
+                    </li>
                 </ul>
             </nav>
 

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Areas/Admin/Controllers/RolesControllerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Areas/Admin/Controllers/RolesControllerTests.cs
@@ -1,0 +1,317 @@
+using AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers;
+using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Areas.Admin.Controllers;
+
+public class RolesControllerTests
+{
+    [Fact]
+    public async Task Index_ReturnsViewWithAllRoles_AndMarksProtectedRole()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+
+        var roles = new List<IdentityRole>
+        {
+            new IdentityRole("Admin") { Id = "1" },
+            new IdentityRole("Editor") { Id = "2" }
+        };
+
+        roleManager.Setup(x => x.Roles).Returns(roles.AsQueryable());
+
+        userManager
+            .Setup(x => x.GetUsersInRoleAsync("Admin"))
+            .ReturnsAsync(new List<ApplicationUser> { new ApplicationUser() });
+
+        userManager
+            .Setup(x => x.GetUsersInRoleAsync("Editor"))
+            .ReturnsAsync(new List<ApplicationUser>());
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsAssignableFrom<IEnumerable<RoleListItemViewModel>>(viewResult.Model).ToList();
+
+        Assert.Equal(2, model.Count);
+
+        var admin = model.Single(r => r.Name == "Admin");
+        Assert.True(admin.IsProtected);
+        Assert.Equal(1, admin.UserCount);
+
+        var editor = model.Single(r => r.Name == "Editor");
+        Assert.False(editor.IsProtected);
+        Assert.Equal(0, editor.UserCount);
+    }
+
+    [Fact]
+    public void Create_Get_ReturnsViewWithEmptyModel()
+    {
+        var controller = CreateController(
+            CreateUserManagerMock().Object,
+            CreateRoleManagerMock().Object);
+
+        var result = controller.Create();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<CreateRoleViewModel>(viewResult.Model);
+        Assert.Equal(string.Empty, model.Name);
+    }
+
+    [Fact]
+    public async Task Create_Post_WithInvalidModelState_ReturnsViewWithModel()
+    {
+        var controller = CreateController(
+            CreateUserManagerMock().Object,
+            CreateRoleManagerMock().Object);
+
+        controller.ModelState.AddModelError("Name", "Required");
+        var model = new CreateRoleViewModel { Name = string.Empty };
+
+        var result = await controller.Create(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Same(model, viewResult.Model);
+    }
+
+    [Fact]
+    public async Task Create_Post_WithDuplicateName_AddsModelErrorAndReturnsView()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(x => x.RoleExistsAsync("Editor")).ReturnsAsync(true);
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+        var model = new CreateRoleViewModel { Name = "Editor" };
+
+        var result = await controller.Create(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Same(model, viewResult.Model);
+        Assert.False(controller.ModelState.IsValid);
+        roleManager.Verify(x => x.CreateAsync(It.IsAny<IdentityRole>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_Post_WithValidModel_CreatesRoleAndRedirectsToIndex()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(x => x.RoleExistsAsync("Editor")).ReturnsAsync(false);
+        roleManager
+            .Setup(x => x.CreateAsync(It.Is<IdentityRole>(r => r.Name == "Editor")))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+        var model = new CreateRoleViewModel { Name = "Editor" };
+
+        var result = await controller.Create(model);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        roleManager.Verify(x => x.CreateAsync(It.Is<IdentityRole>(r => r.Name == "Editor")), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenRoleNotFound_ReturnsNotFound()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(x => x.FindByIdAsync("missing")).ReturnsAsync((IdentityRole?)null);
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+
+        var result = await controller.Edit("missing");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_ReturnsViewWithRoleData()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager
+            .Setup(x => x.FindByIdAsync("1"))
+            .ReturnsAsync(new IdentityRole("Editor") { Id = "1" });
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+
+        var result = await controller.Edit("1");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<EditRoleViewModel>(viewResult.Model);
+        Assert.Equal("1", model.Id);
+        Assert.Equal("Editor", model.Name);
+        Assert.False(model.IsProtected);
+    }
+
+    [Fact]
+    public async Task Edit_Post_WithProtectedRole_ReturnsViewWithErrorAndDoesNotUpdate()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager
+            .Setup(x => x.FindByIdAsync("1"))
+            .ReturnsAsync(new IdentityRole("Admin") { Id = "1" });
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+        var model = new EditRoleViewModel { Id = "1", Name = "Renamed" };
+
+        var result = await controller.Edit(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Same(model, viewResult.Model);
+        Assert.True(model.IsProtected);
+        Assert.False(controller.ModelState.IsValid);
+        roleManager.Verify(x => x.UpdateAsync(It.IsAny<IdentityRole>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Post_WithValidModel_UpdatesRoleAndRedirectsToIndex()
+    {
+        var roleManager = CreateRoleManagerMock();
+        var role = new IdentityRole("Editor") { Id = "1" };
+        roleManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(role);
+        roleManager.Setup(x => x.UpdateAsync(role)).ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+        var model = new EditRoleViewModel { Id = "1", Name = "Contributor" };
+
+        var result = await controller.Edit(model);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Contributor", role.Name);
+        roleManager.Verify(x => x.UpdateAsync(role), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WhenRoleNotFound_ReturnsNotFound()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(x => x.FindByIdAsync("missing")).ReturnsAsync((IdentityRole?)null);
+
+        var controller = CreateController(CreateUserManagerMock().Object, roleManager.Object);
+
+        var result = await controller.Delete("missing");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithProtectedRole_DoesNotDelete()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager
+            .Setup(x => x.FindByIdAsync("1"))
+            .ReturnsAsync(new IdentityRole("Admin") { Id = "1" });
+
+        var userManager = CreateUserManagerMock();
+        userManager
+            .Setup(x => x.GetUsersInRoleAsync("Admin"))
+            .ReturnsAsync(new List<ApplicationUser>());
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.DeleteConfirmed("1");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DeleteRoleViewModel>(viewResult.Model);
+        Assert.True(model.IsProtected);
+        Assert.False(controller.ModelState.IsValid);
+        roleManager.Verify(x => x.DeleteAsync(It.IsAny<IdentityRole>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithUsersAssigned_DoesNotDelete()
+    {
+        var roleManager = CreateRoleManagerMock();
+        roleManager
+            .Setup(x => x.FindByIdAsync("2"))
+            .ReturnsAsync(new IdentityRole("Editor") { Id = "2" });
+
+        var userManager = CreateUserManagerMock();
+        userManager
+            .Setup(x => x.GetUsersInRoleAsync("Editor"))
+            .ReturnsAsync(new List<ApplicationUser> { new ApplicationUser(), new ApplicationUser() });
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.DeleteConfirmed("2");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DeleteRoleViewModel>(viewResult.Model);
+        Assert.Equal(2, model.UserCount);
+        Assert.False(controller.ModelState.IsValid);
+        roleManager.Verify(x => x.DeleteAsync(It.IsAny<IdentityRole>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithValidRole_DeletesAndRedirectsToIndex()
+    {
+        var roleManager = CreateRoleManagerMock();
+        var role = new IdentityRole("Editor") { Id = "2" };
+        roleManager.Setup(x => x.FindByIdAsync("2")).ReturnsAsync(role);
+        roleManager.Setup(x => x.DeleteAsync(role)).ReturnsAsync(IdentityResult.Success);
+
+        var userManager = CreateUserManagerMock();
+        userManager
+            .Setup(x => x.GetUsersInRoleAsync("Editor"))
+            .ReturnsAsync(new List<ApplicationUser>());
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.DeleteConfirmed("2");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        roleManager.Verify(x => x.DeleteAsync(role), Times.Once);
+    }
+
+    private static RolesController CreateController(
+        UserManager<ApplicationUser> userManager,
+        RoleManager<IdentityRole> roleManager)
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new AdminBootstrapOptions
+        {
+            Enabled = true,
+            RoleName = "Admin",
+            Email = "admin@test.local",
+            Password = "Admin123!",
+            DisplayName = "Template Admin"
+        });
+
+        return new RolesController(roleManager, userManager, options);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<RoleManager<IdentityRole>> CreateRoleManagerMock()
+    {
+        var store = new Mock<IRoleStore<IdentityRole>>();
+
+        return new Mock<RoleManager<IdentityRole>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}


### PR DESCRIPTION
## Summary
- New `RolesController` in the Admin area with full CRUD over `IdentityRole`
- 4 ViewModels under `Areas/Admin/ViewModels/` (List/Create/Edit/Delete)
- 4 views under `Areas/Admin/Views/Roles/` matching existing Bootstrap 5 style
- Bootstrap admin role (from `AdminBootstrapOptions.RoleName`) is protected from rename and delete
- Roles with users assigned cannot be deleted
- Sidebar gains a "Roles" link with active-state highlight
- 13 new unit tests in `RolesControllerTests`

No migration needed — uses existing `AspNetRoles` / `AspNetUserRoles` tables.

## Test plan
- [ ] `dotnet build` passes with 0 warnings (verified locally)
- [ ] `dotnet test` passes — 33/33 (verified locally)
- [ ] Log in as admin → sidebar shows **Roles** → list page loads
- [ ] Create a new role "Editor" → appears in list with UserCount = 0
- [ ] Rename "Editor" to "Contributor" → list updates
- [ ] Try to edit/delete the bootstrap "Admin" role → Edit/Delete buttons disabled, server-side block on direct POST
- [ ] Delete "Contributor" → confirmation page → confirm → role removed
- [ ] Non-admin user → `/Admin/Roles` returns 403
