### PR TITLE
Add user management with role assignment in admin area

### DIFF
--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
@@ -1,0 +1,187 @@
+using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
+{
+    [Area("Admin")]
+    [Authorize(Roles = "Admin")]
+    [AutoValidateAntiforgeryToken]
+    public class UsersController : Controller
+    {
+        private readonly UserManager<ApplicationUser> userManager;
+        private readonly RoleManager<IdentityRole> roleManager;
+        private readonly AdminBootstrapOptions bootstrapOptions;
+
+        public UsersController(
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            IOptions<AdminBootstrapOptions> bootstrapOptions)
+        {
+            this.userManager = userManager;
+            this.roleManager = roleManager;
+            this.bootstrapOptions = bootstrapOptions.Value;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var users = userManager.Users.ToList();
+            var items = new List<UserListItemViewModel>();
+
+            foreach (var user in users)
+            {
+                var roles = await userManager.GetRolesAsync(user);
+                items.Add(new UserListItemViewModel
+                {
+                    Id = user.Id,
+                    Email = user.Email ?? string.Empty,
+                    Name = user.Name,
+                    Roles = string.Join(", ", roles.OrderBy(r => r)),
+                    EmailConfirmed = user.EmailConfirmed,
+                    IsProtected = IsProtectedUser(user)
+                });
+            }
+
+            return View(items);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Edit(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return NotFound();
+            }
+
+            var user = await userManager.FindByIdAsync(id);
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            var model = await BuildEditViewModelAsync(user);
+            return View(model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Edit(EditUserViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                model.RoleAssignments = BuildRoleAssignments(model.RoleAssignments);
+                return View(model);
+            }
+
+            var user = await userManager.FindByIdAsync(model.Id);
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            var isProtected = IsProtectedUser(user);
+
+            if (isProtected && !model.EmailConfirmed)
+            {
+                ModelState.AddModelError(string.Empty, "Cannot disable email confirmation for the bootstrap admin user.");
+                model = await BuildEditViewModelAsync(user);
+                return View(model);
+            }
+
+            if (isProtected && model.LockoutEnabled)
+            {
+                ModelState.AddModelError(string.Empty, "Cannot enable lockout for the bootstrap admin user.");
+                model = await BuildEditViewModelAsync(user);
+                return View(model);
+            }
+
+            user.Name = model.Name.Trim();
+            user.EmailConfirmed = model.EmailConfirmed;
+            user.LockoutEnabled = model.LockoutEnabled;
+
+            var updateResult = await userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
+            {
+                foreach (var error in updateResult.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                model = await BuildEditViewModelAsync(user);
+                return View(model);
+            }
+
+            await SyncRoleAssignmentsAsync(user, model.RoleAssignments, isProtected);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        private async Task SyncRoleAssignmentsAsync(
+            ApplicationUser user,
+            List<RoleAssignmentViewModel> assignments,
+            bool isProtected)
+        {
+            var currentRoles = await userManager.GetRolesAsync(user);
+
+            foreach (var assignment in assignments)
+            {
+                var isCurrentlyInRole = currentRoles.Contains(assignment.RoleName, StringComparer.OrdinalIgnoreCase);
+
+                if (assignment.IsAssigned && !isCurrentlyInRole)
+                {
+                    await userManager.AddToRoleAsync(user, assignment.RoleName);
+                }
+                else if (!assignment.IsAssigned && isCurrentlyInRole)
+                {
+                    if (isProtected && string.Equals(assignment.RoleName, bootstrapOptions.RoleName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    await userManager.RemoveFromRoleAsync(user, assignment.RoleName);
+                }
+            }
+        }
+
+        private async Task<EditUserViewModel> BuildEditViewModelAsync(ApplicationUser user)
+        {
+            var userRoles = await userManager.GetRolesAsync(user);
+            var allRoles = roleManager.Roles.OrderBy(r => r.Name).ToList();
+
+            return new EditUserViewModel
+            {
+                Id = user.Id,
+                Email = user.Email ?? string.Empty,
+                Name = user.Name,
+                EmailConfirmed = user.EmailConfirmed,
+                LockoutEnabled = user.LockoutEnabled,
+                IsProtected = IsProtectedUser(user),
+                RoleAssignments = allRoles.Select(role => new RoleAssignmentViewModel
+                {
+                    RoleName = role.Name ?? string.Empty,
+                    IsAssigned = userRoles.Contains(role.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                }).ToList()
+            };
+        }
+
+        private List<RoleAssignmentViewModel> BuildRoleAssignments(
+            List<RoleAssignmentViewModel> submitted)
+        {
+            var allRoles = roleManager.Roles.OrderBy(r => r.Name).ToList();
+
+            return allRoles.Select(role => new RoleAssignmentViewModel
+            {
+                RoleName = role.Name ?? string.Empty,
+                IsAssigned = submitted.Any(s =>
+                    string.Equals(s.RoleName, role.Name, StringComparison.OrdinalIgnoreCase) && s.IsAssigned)
+            }).ToList();
+        }
+
+        private bool IsProtectedUser(ApplicationUser user)
+        {
+            return string.Equals(user.Email, bootstrapOptions.Email, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/EditUserViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/EditUserViewModel.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class EditUserViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, MinimumLength = 1, ErrorMessage = "The {0} must be between {2} and {1} characters.")]
+        [Display(Name = "Name")]
+        public string Name { get; set; } = string.Empty;
+
+        [Display(Name = "Email confirmed")]
+        public bool EmailConfirmed { get; set; }
+
+        [Display(Name = "Lockout enabled")]
+        public bool LockoutEnabled { get; set; }
+
+        public bool IsProtected { get; set; }
+
+        public List<RoleAssignmentViewModel> RoleAssignments { get; set; } = new();
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/RoleAssignmentViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/RoleAssignmentViewModel.cs
@@ -1,0 +1,9 @@
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class RoleAssignmentViewModel
+    {
+        public string RoleName { get; set; } = string.Empty;
+
+        public bool IsAssigned { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/UserListItemViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/ViewModels/UserListItemViewModel.cs
@@ -1,0 +1,17 @@
+namespace AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+{
+    public class UserListItemViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+
+        public string Roles { get; set; } = string.Empty;
+
+        public bool EmailConfirmed { get; set; }
+
+        public bool IsProtected { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
@@ -44,6 +44,12 @@
                             Roles
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Users" ? "active fw-semibold" : "text-dark")"
+                           asp-area="Admin" asp-controller="Users" asp-action="Index">
+                            Users
+                        </a>
+                    </li>
                 </ul>
             </nav>
 

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Edit.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Edit.cshtml
@@ -1,0 +1,97 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model EditUserViewModel
+
+@{
+    ViewData["Title"] = "Edit user";
+}
+
+<div class="mb-4">
+    <h1 class="h3">Edit user</h1>
+</div>
+
+@if (Model.IsProtected)
+{
+    <div class="alert alert-warning">
+        This is the bootstrap admin user. Some fields and role assignments are protected.
+    </div>
+}
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">User details</div>
+            <div class="card-body">
+                <form asp-area="Admin" asp-controller="Users" asp-action="Edit" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <input type="hidden" asp-for="Id" />
+                    <input type="hidden" asp-for="IsProtected" />
+
+                    <div class="mb-3">
+                        <label class="form-label">Email</label>
+                        <input type="text" class="form-control" value="@Model.Email" disabled />
+                        <input type="hidden" asp-for="Email" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label asp-for="Name" class="form-label"></label>
+                        <input asp-for="Name" class="form-control" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input asp-for="EmailConfirmed" class="form-check-input"
+                               disabled="@(Model.IsProtected && Model.EmailConfirmed)" />
+                        <label asp-for="EmailConfirmed" class="form-check-label"></label>
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input asp-for="LockoutEnabled" class="form-check-input"
+                               disabled="@(Model.IsProtected && !Model.LockoutEnabled)" />
+                        <label asp-for="LockoutEnabled" class="form-check-label"></label>
+                    </div>
+
+                    @if (Model.RoleAssignments.Any())
+                    {
+                        <hr />
+                        <h6 class="mb-3">Role assignments</h6>
+                        @for (var i = 0; i < Model.RoleAssignments.Count; i++)
+                        {
+                            var isAdminRole = string.Equals(Model.RoleAssignments[i].RoleName,
+                                "Admin", StringComparison.OrdinalIgnoreCase);
+                            var isDisabled = Model.IsProtected && isAdminRole && Model.RoleAssignments[i].IsAssigned;
+
+                            <input type="hidden" name="RoleAssignments[@i].RoleName"
+                                   value="@Model.RoleAssignments[i].RoleName" />
+                            <div class="mb-2 form-check">
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       id="RoleAssignments_@(i)__IsAssigned"
+                                       name="RoleAssignments[@i].IsAssigned"
+                                       value="true"
+                                       checked="@(Model.RoleAssignments[i].IsAssigned ? "checked" : null)"
+                                       disabled="@isDisabled" />
+                                @if (isDisabled)
+                                {
+                                    <input type="hidden" name="RoleAssignments[@i].IsAssigned" value="true" />
+                                }
+                                <label class="form-check-label" for="RoleAssignments_@(i)__IsAssigned">
+                                    @Model.RoleAssignments[i].RoleName
+                                </label>
+                            </div>
+                        }
+                    }
+
+                    <div class="d-flex gap-2 mt-3">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                        <a class="btn btn-outline-secondary" asp-area="Admin" asp-controller="Users" asp-action="Index">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Edit.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Edit.cshtml
@@ -61,6 +61,7 @@
                                 "Admin", StringComparison.OrdinalIgnoreCase);
                             var isDisabled = Model.IsProtected && isAdminRole && Model.RoleAssignments[i].IsAssigned;
 
+                            // Ni trebaat hidden polinjata zatoa sto samo selektiranite ke se pratat vo response, a ne selektiranite ke se ignoriraat. Isto ni treba for za indexiranje da moze da se povrzat RoleName so IsAssigned.
                             <input type="hidden" name="RoleAssignments[@i].RoleName"
                                    value="@Model.RoleAssignments[i].RoleName" />
                             <div class="mb-2 form-check">

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Index.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Index.cshtml
@@ -1,0 +1,77 @@
+@using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels
+@model IEnumerable<UserListItemViewModel>
+
+@{
+    ViewData["Title"] = "Users";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3">Users</h1>
+</div>
+
+<div class="card">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0 align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Email</th>
+                    <th scope="col">Roles</th>
+                    <th scope="col" class="text-center">Email confirmed</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (!Model.Any())
+                {
+                    <tr>
+                        <td colspan="5" class="text-center text-muted py-4">No users found.</td>
+                    </tr>
+                }
+                else
+                {
+                    foreach (var user in Model)
+                    {
+                        <tr>
+                            <td>
+                                @user.Name
+                                @if (user.IsProtected)
+                                {
+                                    <span class="badge text-bg-secondary ms-2">Protected</span>
+                                }
+                            </td>
+                            <td>@user.Email</td>
+                            <td>
+                                @if (!string.IsNullOrEmpty(user.Roles))
+                                {
+                                    foreach (var role in user.Roles.Split(", "))
+                                    {
+                                        <span class="badge text-bg-info me-1">@role</span>
+                                    }
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @if (user.EmailConfirmed)
+                                {
+                                    <span class="badge text-bg-success">Yes</span>
+                                }
+                                else
+                                {
+                                    <span class="badge text-bg-warning">No</span>
+                                }
+                            </td>
+                            <td class="text-end">
+                                <a class="btn btn-sm btn-outline-primary"
+                                   asp-area="Admin" asp-controller="Users" asp-action="Edit" asp-route-id="@user.Id">Edit</a>
+                            </td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Index.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Views/Users/Index.cshtml
@@ -22,7 +22,7 @@
                 </tr>
             </thead>
             <tbody>
-                @if (!Model.Any())
+                @if (Model == null || !Model.Any())
                 {
                     <tr>
                         <td colspan="5" class="text-center text-muted py-4">No users found.</td>

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Areas/Admin/Controllers/UsersControllerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Areas/Admin/Controllers/UsersControllerTests.cs
@@ -1,0 +1,362 @@
+using AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers;
+using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Areas.Admin.Controllers;
+
+public class UsersControllerTests
+{
+    [Fact]
+    public async Task Edit_Get_WhenUserNotFound_ReturnsNotFound()
+    {
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+        var controller = CreateController(userManager.Object, CreateRoleManagerMock().Object);
+
+        var result = await controller.Edit("missing");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WhenIdIsEmpty_ReturnsNotFound()
+    {
+        var controller = CreateController(CreateUserManagerMock().Object, CreateRoleManagerMock().Object);
+
+        var result = await controller.Edit("");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_ReturnsViewWithUserDataAndRoles()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "user@test.local",
+            UserName = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true,
+            LockoutEnabled = false
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+        var roles = new List<IdentityRole>
+        {
+            new IdentityRole("Admin") { Id = "r1" },
+            new IdentityRole("Editor") { Id = "r2" }
+        };
+        roleManager.Setup(x => x.Roles).Returns(roles.AsQueryable());
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.Edit("1");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<EditUserViewModel>(viewResult.Model);
+        Assert.Equal("1", model.Id);
+        Assert.Equal("Test User", model.Name);
+        Assert.True(model.EmailConfirmed);
+        Assert.Equal(2, model.RoleAssignments.Count);
+
+        var adminAssignment = model.RoleAssignments.Single(r => r.RoleName == "Admin");
+        Assert.True(adminAssignment.IsAssigned);
+
+        var editorAssignment = model.RoleAssignments.Single(r => r.RoleName == "Editor");
+        Assert.False(editorAssignment.IsAssigned);
+    }
+
+    [Fact]
+    public async Task Edit_Post_WithInvalidModelState_ReturnsView()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(x => x.Roles).Returns(new List<IdentityRole>().AsQueryable());
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+        controller.ModelState.AddModelError("Name", "Required");
+
+        var model = new EditUserViewModel { Id = "1", Name = "" };
+
+        var result = await controller.Edit(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Same(model, viewResult.Model);
+    }
+
+    [Fact]
+    public async Task Edit_Post_WithValidModel_UpdatesUserAndRedirectsToIndex()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "Old Name",
+            EmailConfirmed = false,
+            LockoutEnabled = false
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        userManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string>());
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "New Name",
+            EmailConfirmed = true,
+            LockoutEnabled = false,
+            RoleAssignments = new List<RoleAssignmentViewModel>()
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.Edit(model);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("New Name", user.Name);
+        Assert.True(user.EmailConfirmed);
+        userManager.Verify(x => x.UpdateAsync(user), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_AddsNewRoleAssignment()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        userManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string>());
+        userManager.Setup(x => x.AddToRoleAsync(user, "Editor")).ReturnsAsync(IdentityResult.Success);
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true,
+            RoleAssignments = new List<RoleAssignmentViewModel>
+            {
+                new RoleAssignmentViewModel { RoleName = "Editor", IsAssigned = true }
+            }
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        await controller.Edit(model);
+
+        userManager.Verify(x => x.AddToRoleAsync(user, "Editor"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_RemovesRoleAssignment()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        userManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Editor" });
+        userManager.Setup(x => x.RemoveFromRoleAsync(user, "Editor")).ReturnsAsync(IdentityResult.Success);
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true,
+            RoleAssignments = new List<RoleAssignmentViewModel>
+            {
+                new RoleAssignmentViewModel { RoleName = "Editor", IsAssigned = false }
+            }
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        await controller.Edit(model);
+
+        userManager.Verify(x => x.RemoveFromRoleAsync(user, "Editor"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_ProtectedUser_CannotRemoveAdminRole()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = true
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        userManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = true,
+            RoleAssignments = new List<RoleAssignmentViewModel>
+            {
+                new RoleAssignmentViewModel { RoleName = "Admin", IsAssigned = false }
+            }
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        await controller.Edit(model);
+
+        userManager.Verify(x => x.RemoveFromRoleAsync(user, "Admin"), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Post_ProtectedUser_CannotDisableEmailConfirmed()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = true
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        roleManager.Setup(x => x.Roles).Returns(new List<IdentityRole>().AsQueryable());
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = false,
+            RoleAssignments = new List<RoleAssignmentViewModel>()
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.Edit(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+        userManager.Verify(x => x.UpdateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Post_ProtectedUser_CannotEnableLockout()
+    {
+        var userManager = CreateUserManagerMock();
+        var roleManager = CreateRoleManagerMock();
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = true,
+            LockoutEnabled = false
+        };
+
+        userManager.Setup(x => x.FindByIdAsync("1")).ReturnsAsync(user);
+        roleManager.Setup(x => x.Roles).Returns(new List<IdentityRole>().AsQueryable());
+        userManager.Setup(x => x.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+        var model = new EditUserViewModel
+        {
+            Id = "1",
+            Email = "admin@test.local",
+            Name = "Template Admin",
+            EmailConfirmed = true,
+            LockoutEnabled = true,
+            RoleAssignments = new List<RoleAssignmentViewModel>()
+        };
+
+        var controller = CreateController(userManager.Object, roleManager.Object);
+
+        var result = await controller.Edit(model);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+        userManager.Verify(x => x.UpdateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    private static UsersController CreateController(
+        UserManager<ApplicationUser> userManager,
+        RoleManager<IdentityRole> roleManager)
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new AdminBootstrapOptions
+        {
+            Enabled = true,
+            RoleName = "Admin",
+            Email = "admin@test.local",
+            Password = "Admin123!",
+            DisplayName = "Template Admin"
+        });
+
+        return new UsersController(userManager, roleManager, options);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<RoleManager<IdentityRole>> CreateRoleManagerMock()
+    {
+        var store = new Mock<IRoleStore<IdentityRole>>();
+
+        return new Mock<RoleManager<IdentityRole>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}


### PR DESCRIPTION
Adds UsersController with user list and edit pages. Edit form allows changing Name, toggling EmailConfirmed and LockoutEnabled, and assigning/unassigning roles via checkbox list. Bootstrap admin user is protected from lockout, email unconfirmation, and Admin role removal. Sidebar gains a Users link. 10 unit tests cover the controller paths.

## Summary

Describe the purpose of this pull request clearly and briefly.

## Related Issue

Closes #

## Changes Made

- 
- 
- 

## Why This Change Was Needed

Explain the problem or goal this PR addresses.

## Screenshots / UI Notes

Add screenshots or UI notes if applicable.

## Testing

Describe how this was tested.

- [ ] Build succeeds
- [ ] Tests pass
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project structure and conventions
- [ ] No sensitive data was added
- [ ] Documentation updated where needed
- [ ] Related issue linked
- [ ] Ready for review