### PR TITLE
Implement policy-based authorization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Role management**: RolesController — create, rename, delete roles. Bootstrap admin role is protected.
 - **User management**: UsersController — edit user (Name, EmailConfirmed, LockoutEnabled), assign/unassign roles via checkbox list. Bootstrap admin user is protected.
 - **Auth cookie**: 60-min expiration, sliding, HttpOnly, RequireConfirmedEmail = true
-- **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `RequireEmailConfirmed`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
+- **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
 - **Error handling**: `ErrorController` with ServerError (500) and StatusCodeError (404/403)
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,11 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Role management**: RolesController — create, rename, delete roles. Bootstrap admin role is protected.
 - **User management**: UsersController — edit user (Name, EmailConfirmed, LockoutEnabled), assign/unassign roles via checkbox list. Bootstrap admin user is protected.
 - **Auth cookie**: 60-min expiration, sliding, HttpOnly, RequireConfirmedEmail = true
+- **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `RequireEmailConfirmed`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
 - **Error handling**: `ErrorController` with ServerError (500) and StatusCodeError (404/403)
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check
-- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`
+- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`
 
 ## Completed Features
 
@@ -32,13 +33,14 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - Admin bootstrap seeding
 - Admin area with Dashboard, Roles CRUD, Users management, role assignment
 - Bootstrap admin role/user protection (cannot delete/rename admin role, cannot lock out admin user)
+- Policy-based authorization (named policies + custom requirement/handler)
 - Error handling (500, 404, 403)
 - Serilog structured logging (Console + File with daily rolling)
 - Health check endpoint at `/health`
 - GitHub Actions CI (build + test)
 - GitHub Actions CD (IIS deployment to staging)
 - Data protection keys persisted to file system
-- 43+ unit and integration tests
+- 49+ unit and integration tests
 
 ## Branching
 

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/DashboardController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/DashboardController.cs
@@ -1,10 +1,11 @@
+using AspNetCoreMvcTemplate.Web.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
     public class DashboardController : Controller
     {
         public IActionResult Index()

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
@@ -1,4 +1,5 @@
 using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Authorization;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.Options;
 using Microsoft.AspNetCore.Authorization;
@@ -9,7 +10,7 @@ using Microsoft.Extensions.Options;
 namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
     [AutoValidateAntiforgeryToken]
     public class RolesController : Controller
     {

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
+using AspNetCoreMvcTemplate.Web.Authorization;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.Options;
 using Microsoft.AspNetCore.Authorization;
@@ -9,7 +10,7 @@ using Microsoft.Extensions.Options;
 namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
     [AutoValidateAntiforgeryToken]
     public class UsersController : Controller
     {

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/ActiveUserAuthorizationHandler.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/ActiveUserAuthorizationHandler.cs
@@ -1,0 +1,46 @@
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+
+namespace AspNetCoreMvcTemplate.Web.Authorization
+{
+    // Demonstrira kako da se injektira UserManager vo handler i da se kombiniraat
+    // proverki na ClaimsPrincipal so podatoci od user store-ot.
+    public class ActiveUserAuthorizationHandler : AuthorizationHandler<ActiveUserRequirement>
+    {
+        private readonly UserManager<ApplicationUser> userManager;
+
+        public ActiveUserAuthorizationHandler(UserManager<ApplicationUser> userManager)
+        {
+            this.userManager = userManager;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            ActiveUserRequirement requirement)
+        {
+            if (context.User?.Identity is null || !context.User.Identity.IsAuthenticated)
+            {
+                return;
+            }
+
+            var user = await userManager.GetUserAsync(context.User);
+            if (user is null)
+            {
+                return;
+            }
+
+            if (!user.EmailConfirmed)
+            {
+                return;
+            }
+
+            if (user.LockoutEnd.HasValue && user.LockoutEnd.Value > DateTimeOffset.UtcNow)
+            {
+                return;
+            }
+
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/ActiveUserRequirement.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/ActiveUserRequirement.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace AspNetCoreMvcTemplate.Web.Authorization
+{
+    // Marker requirement - samo tip, bez logika.
+    // Logikata e vo ActiveUserAuthorizationHandler.
+    public class ActiveUserRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
@@ -1,0 +1,11 @@
+namespace AspNetCoreMvcTemplate.Web.Authorization
+{
+    // Centralna lokacija za site imeto na politikite za avtorizacija.
+    // Se koristi kako konstanti za da se izbegnat magicni stringovi niz kontrolerite.
+    public static class AuthorizationPolicies
+    {
+        public const string AdminOnly = "AdminOnly";
+        public const string RequireEmailConfirmed = "RequireEmailConfirmed";
+        public const string ActiveUser = "ActiveUser";
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
@@ -5,7 +5,6 @@ namespace AspNetCoreMvcTemplate.Web.Authorization
     public static class AuthorizationPolicies
     {
         public const string AdminOnly = "AdminOnly";
-        public const string RequireEmailConfirmed = "RequireEmailConfirmed";
         public const string ActiveUser = "ActiveUser";
     }
 }

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/Roles.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/Roles.cs
@@ -1,0 +1,7 @@
+﻿namespace AspNetCoreMvcTemplate.Web.Authorization
+{
+    public class Roles
+    {
+        public const string Admin = "Admin";
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -15,12 +15,6 @@ namespace AspNetCoreMvcTemplate.Web.Extensions
                 options.AddPolicy(AuthorizationPolicies.AdminOnly, policy =>
                     policy.RequireRole(Roles.Admin));
 
-                // Claims based policy koristejki RequireAssertion za fleksibilna logika.
-                options.AddPolicy(AuthorizationPolicies.RequireEmailConfirmed, policy =>
-                    policy.RequireAuthenticatedUser()
-                          .RequireAssertion(ctx =>
-                              ctx.User.HasClaim(c => c.Type == "email_verified" && c.Value == "true")));
-
                 // Custom requirement - logikata e vo ActiveUserAuthorizationHandler.
                 options.AddPolicy(AuthorizationPolicies.ActiveUser, policy =>
                     policy.Requirements.Add(new ActiveUserRequirement()));

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using AspNetCoreMvcTemplate.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+
+namespace AspNetCoreMvcTemplate.Web.Extensions
+{
+    public static class AuthorizationServiceCollectionExtensions
+    {
+        public static IServiceCollection AddAuthorizationPolicies(this IServiceCollection services)
+        {
+            services.AddScoped<IAuthorizationHandler, ActiveUserAuthorizationHandler>();
+
+            services.AddAuthorization(options =>
+            {
+                // Ednostavna role based policy. Zamena za [Authorize(Roles = "Admin")].
+                options.AddPolicy(AuthorizationPolicies.AdminOnly, policy =>
+                    policy.RequireRole(Roles.Admin));
+
+                // Claims based policy koristejki RequireAssertion za fleksibilna logika.
+                options.AddPolicy(AuthorizationPolicies.RequireEmailConfirmed, policy =>
+                    policy.RequireAuthenticatedUser()
+                          .RequireAssertion(ctx =>
+                              ctx.User.HasClaim(c => c.Type == "email_verified" && c.Value == "true")));
+
+                // Custom requirement - logikata e vo ActiveUserAuthorizationHandler.
+                options.AddPolicy(AuthorizationPolicies.ActiveUser, policy =>
+                    policy.Requirements.Add(new ActiveUserRequirement()));
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Program.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Program.cs
@@ -52,6 +52,8 @@ namespace AspNetCoreMvcTemplate.Web
             .AddEntityFrameworkStores<ApplicationDbContext>()
             .AddDefaultTokenProviders();
 
+            builder.Services.AddAuthorizationPolicies();
+
             builder.Services.ConfigureApplicationCookie(options =>
             {
                 options.LoginPath = "/Account/Login";

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Authorization/ActiveUserAuthorizationHandlerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Authorization/ActiveUserAuthorizationHandlerTests.cs
@@ -1,0 +1,143 @@
+using System.Security.Claims;
+using AspNetCoreMvcTemplate.Web.Authorization;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Authorization;
+
+public class ActiveUserAuthorizationHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenUserNotAuthenticated_DoesNotSucceed()
+    {
+        var userManager = CreateUserManagerMock();
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity()); // neautentikuvan
+        var context = new AuthorizationHandlerContext(new[] { requirement }, anonymous, resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserManagerReturnsNull_DoesNotSucceed()
+    {
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync((ApplicationUser?)null);
+
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var context = new AuthorizationHandlerContext(new[] { requirement }, CreateAuthenticatedUser(), resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailNotConfirmed_DoesNotSucceed()
+    {
+        var user = new ApplicationUser { Id = "1", EmailConfirmed = false };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var context = new AuthorizationHandlerContext(new[] { requirement }, CreateAuthenticatedUser(), resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLockoutEndInFuture_DoesNotSucceed()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            EmailConfirmed = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(10)
+        };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var context = new AuthorizationHandlerContext(new[] { requirement }, CreateAuthenticatedUser(), resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailConfirmedAndNotLockedOut_Succeeds()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            EmailConfirmed = true,
+            LockoutEnd = null
+        };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var context = new AuthorizationHandlerContext(new[] { requirement }, CreateAuthenticatedUser(), resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLockoutEndInPast_Succeeds()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            EmailConfirmed = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(-10) // istechen lockout
+        };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+
+        var handler = new ActiveUserAuthorizationHandler(userManager.Object);
+        var requirement = new ActiveUserRequirement();
+        var context = new AuthorizationHandlerContext(new[] { requirement }, CreateAuthenticatedUser(), resource: null);
+
+        await handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    private static ClaimsPrincipal CreateAuthenticatedUser()
+    {
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, "1") },
+            authenticationType: "TestAuth");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces policy-based authorization and replaces direct role checks with centralized policies. It also adds a custom ActiveUser requirement for runtime user validation.

## Changes

### Authorization infrastructure
- Added `Authorization` folder with:
  - `AuthorizationPolicies`
  - `ActiveUserRequirement`
  - `ActiveUserAuthorizationHandler`

### Service configuration
- Introduced `AddAuthorizationPolicies()` extension method
- Registered custom `IAuthorizationHandler`
- Configured policies:
  - `AdminOnly` (role-based)
  - `ActiveUser` (custom requirement)

### Controller updates
- Replaced `[Authorize(Roles = "Admin")]` with:
  - `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`

## Behavior

### AdminOnly
- Restricts access to users in the `Admin` role

### ActiveUser
- Ensures user:
  - is authenticated
  - has confirmed email
  - is not locked out

## Why

- Improves flexibility and maintainability of authorization
- Centralizes authorization logic
- Aligns template with real-world ASP.NET Core practices
- Enables runtime validation beyond login-time checks

## Notes for reviewers

- No breaking changes expected
- Existing functionality preserved (Admin access still works as before)
- `ActiveUser` policy is implemented but not yet widely applied (planned for next branch)

## Next steps

- Decide where to apply `ActiveUser` policy (global vs selective)
- Possibly introduce base controller or global filter
- Expand user status model (e.g. IsActive flag)