### PR TITLE
Implement claims principal factory and enable email_verified policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Role management**: RolesController — create, rename, delete roles. Bootstrap admin role is protected.
 - **User management**: UsersController — edit user (Name, EmailConfirmed, LockoutEnabled), assign/unassign roles via checkbox list. Bootstrap admin user is protected.
 - **Auth cookie**: 60-min expiration, sliding, HttpOnly, RequireConfirmedEmail = true
-- **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
+- **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `RequireEmailConfirmed`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
+- **Claims pipeline**: `ApplicationUserClaimsPrincipalFactory` overrides `UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>` to emit custom claims at sign-in (`email_verified` from `EmailConfirmed`, `name` from `ApplicationUser.Name`). Registered via `.AddClaimsPrincipalFactory<>()` in Identity setup. The `RequireEmailConfirmed` policy consumes the `email_verified` claim.
 - **Error handling**: `ErrorController` with ServerError (500) and StatusCodeError (404/403)
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check
@@ -34,13 +35,14 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - Admin area with Dashboard, Roles CRUD, Users management, role assignment
 - Bootstrap admin role/user protection (cannot delete/rename admin role, cannot lock out admin user)
 - Policy-based authorization (named policies + custom requirement/handler)
+- Custom claims pipeline (`UserClaimsPrincipalFactory` emits `email_verified`, `name`)
 - Error handling (500, 404, 403)
 - Serilog structured logging (Console + File with daily rolling)
 - Health check endpoint at `/health`
 - GitHub Actions CI (build + test)
 - GitHub Actions CD (IIS deployment to staging)
 - Data protection keys persisted to file system
-- 49+ unit and integration tests
+- 53+ unit and integration tests
 
 ## Branching
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.202",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/ApplicationUserClaimsPrincipalFactory.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/ApplicationUserClaimsPrincipalFactory.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Authorization
+{
+    // Claims dodadeni tuka se cuvaat vo auth cookie i se koristat za authorization checks.
+    // Be careful: Promenite vo DB nema da afektiraat dodeka userot ne napravi re-authenticate.
+
+    public class ApplicationUserClaimsPrincipalFactory
+        : UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>
+    {
+        public ApplicationUserClaimsPrincipalFactory(
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            IOptions<IdentityOptions > optionsAccessor)
+            : base(userManager, roleManager, optionsAccessor)
+        {
+        }
+
+        protected override async Task<ClaimsIdentity> GenerateClaimsAsync(ApplicationUser user)
+        {
+            var identity = await base.GenerateClaimsAsync(user);
+
+            identity.AddClaim(new Claim("email_verified", user.EmailConfirmed ? "true" : "false"));
+
+            if (!string.IsNullOrWhiteSpace(user.Name))
+            {
+                identity.AddClaim(new Claim("name", user.Name));
+            }
+
+            return identity;
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Authorization/AuthorizationPolicies.cs
@@ -5,6 +5,7 @@ namespace AspNetCoreMvcTemplate.Web.Authorization
     public static class AuthorizationPolicies
     {
         public const string AdminOnly = "AdminOnly";
+        public const string RequireEmailConfirmed = "RequireEmailConfirmed";
         public const string ActiveUser = "ActiveUser";
     }
 }

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -15,6 +15,12 @@ namespace AspNetCoreMvcTemplate.Web.Extensions
                 options.AddPolicy(AuthorizationPolicies.AdminOnly, policy =>
                     policy.RequireRole(Roles.Admin));
 
+                // Claims based policy. email_verified claim se zima od ApplicationUserClaimsPrincipalFactory.
+                options.AddPolicy(AuthorizationPolicies.RequireEmailConfirmed, policy =>
+                    policy.RequireAuthenticatedUser()
+                          .RequireAssertion(ctx =>
+                              ctx.User.HasClaim(c => c.Type == "email_verified" && c.Value == "true")));
+
                 // Custom requirement - logikata e vo ActiveUserAuthorizationHandler.
                 options.AddPolicy(AuthorizationPolicies.ActiveUser, policy =>
                     policy.Requirements.Add(new ActiveUserRequirement()));

--- a/src/AspNetCoreMvcTemplate.Web/Program.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Program.cs
@@ -1,4 +1,5 @@
 using AspNetCoreMvcTemplate.Emailing.DependencyInjection;
+using AspNetCoreMvcTemplate.Web.Authorization;
 using AspNetCoreMvcTemplate.Web.Data;
 using AspNetCoreMvcTemplate.Web.Extensions;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
@@ -50,7 +51,8 @@ namespace AspNetCoreMvcTemplate.Web
                 options.User.RequireUniqueEmail = true;
             })
             .AddEntityFrameworkStores<ApplicationDbContext>()
-            .AddDefaultTokenProviders();
+            .AddDefaultTokenProviders()
+            .AddClaimsPrincipalFactory<ApplicationUserClaimsPrincipalFactory>();
 
             builder.Services.AddAuthorizationPolicies();
 

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Authorization/ApplicationUserClaimsPrincipalFactoryTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Authorization/ApplicationUserClaimsPrincipalFactoryTests.cs
@@ -1,0 +1,142 @@
+using System.Security.Claims;
+using AspNetCoreMvcTemplate.Web.Authorization;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Authorization;
+
+public class ApplicationUserClaimsPrincipalFactoryTests
+{
+    [Fact]
+    public async Task GenerateClaims_WhenEmailConfirmed_AddsEmailVerifiedTrueClaim()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            UserName = "user@test.local",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = true
+        };
+        var factory = CreateFactory(user);
+
+        var identity = await factory.InvokeGenerateClaimsAsync(user);
+
+        Assert.Contains(identity.Claims, c => c.Type == "email_verified" && c.Value == "true");
+    }
+
+    [Fact]
+    public async Task GenerateClaims_WhenEmailNotConfirmed_AddsEmailVerifiedFalseClaim()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            UserName = "user@test.local",
+            Email = "user@test.local",
+            Name = "Test User",
+            EmailConfirmed = false
+        };
+        var factory = CreateFactory(user);
+
+        var identity = await factory.InvokeGenerateClaimsAsync(user);
+
+        Assert.Contains(identity.Claims, c => c.Type == "email_verified" && c.Value == "false");
+    }
+
+    [Fact]
+    public async Task GenerateClaims_WhenNameIsSet_AddsNameClaim()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            UserName = "user@test.local",
+            Email = "user@test.local",
+            Name = "Mile Petkovski",
+            EmailConfirmed = true
+        };
+        var factory = CreateFactory(user);
+
+        var identity = await factory.InvokeGenerateClaimsAsync(user);
+
+        Assert.Contains(identity.Claims, c => c.Type == "name" && c.Value == "Mile Petkovski");
+    }
+
+    [Fact]
+    public async Task GenerateClaims_WhenNameIsEmpty_DoesNotAddNameClaim()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            UserName = "user@test.local",
+            Email = "user@test.local",
+            Name = string.Empty,
+            EmailConfirmed = true
+        };
+        var factory = CreateFactory(user);
+
+        var identity = await factory.InvokeGenerateClaimsAsync(user);
+
+        Assert.DoesNotContain(identity.Claims, c => c.Type == "name");
+    }
+
+    private static TestableFactory CreateFactory(ApplicationUser user)
+    {
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(x => x.GetUserIdAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(user.Id);
+        userManager.Setup(x => x.GetUserNameAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(user.UserName);
+        userManager.Setup(x => x.SupportsUserEmail).Returns(true);
+        userManager.Setup(x => x.GetEmailAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(user.Email);
+        userManager.Setup(x => x.SupportsUserSecurityStamp).Returns(false);
+        userManager.Setup(x => x.SupportsUserClaim).Returns(false);
+
+        var roleManager = CreateRoleManagerMock();
+        var options = Microsoft.Extensions.Options.Options.Create(new IdentityOptions());
+
+        return new TestableFactory(userManager.Object, roleManager.Object, options);
+    }
+
+    // Otvora pristap do protected GenerateClaimsAsync za testovi.
+    private class TestableFactory : ApplicationUserClaimsPrincipalFactory
+    {
+        public TestableFactory(
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            IOptions<IdentityOptions> options)
+            : base(userManager, roleManager, options)
+        {
+        }
+
+        public Task<ClaimsIdentity> InvokeGenerateClaimsAsync(ApplicationUser user)
+            => GenerateClaimsAsync(user);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<RoleManager<IdentityRole>> CreateRoleManagerMock()
+    {
+        var store = new Mock<IRoleStore<IdentityRole>>();
+
+        return new Mock<RoleManager<IdentityRole>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a custom ClaimsPrincipal factory to generate application-specific claims and restores the `RequireEmailConfirmed` policy with a working claim source.

## Changes

### Claims pipeline
- Added `ApplicationUserClaimsPrincipalFactory`
- Injected into Identity configuration
- Emits:
  - `email_verified` claim based on `EmailConfirmed`
  - `name` claim for UI/identity usage

### Authorization updates
- Re-added `RequireEmailConfirmed` policy
- Policy now uses claim-based assertion:
  - `email_verified == true`

### Configuration
- Updated `Program.cs` to include:
  ```csharp
  .AddClaimsPrincipalFactory<ApplicationUserClaimsPrincipalFactory>();