### PR TITLE
Add external authentication providers (Google/Facebook/Microsoft-ready)

### DIFF
--- a/.github/workflows/deploy-iis.yml
+++ b/.github/workflows/deploy-iis.yml
@@ -90,15 +90,34 @@ jobs:
         shell: powershell
         env:
           ADMIN_PASSWORD: ${{ secrets.ADMIN_BOOTSTRAP_PASSWORD }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          MICROSOFT_CLIENT_ID: ${{ secrets.MICROSOFT_CLIENT_ID }}
+          MICROSOFT_CLIENT_SECRET: ${{ secrets.MICROSOFT_CLIENT_SECRET }}
+          FACEBOOK_APP_ID: ${{ secrets.FACEBOOK_APP_ID }}
+          FACEBOOK_APP_SECRET: ${{ secrets.FACEBOOK_APP_SECRET }}
         run: |
           $webConfigPath = 'D:\Sites\AspNetCoreMvcTemplate\current\web.config'
           [xml]$xml = Get-Content $webConfigPath
           $envVars = $xml.configuration.location.'system.webServer'.aspNetCore.environmentVariables
 
-          $passwordVar = $xml.CreateElement('environmentVariable')
-          $passwordVar.SetAttribute('name', 'AdminBootstrap__Password')
-          $passwordVar.SetAttribute('value', $env:ADMIN_PASSWORD)
-          $envVars.AppendChild($passwordVar) | Out-Null
+          # Helper: dodava environmentVariable samo ako vrednosta ne e prazna.
+          # Dozvoluva pipeline da rotira tajni bez crash na deploymentot.
+          function Add-EnvVarIfPresent([string]$name, [string]$value) {
+            if ([string]::IsNullOrWhiteSpace($value)) { return }
+            $node = $xml.CreateElement('environmentVariable')
+            $node.SetAttribute('name', $name)
+            $node.SetAttribute('value', $value)
+            $envVars.AppendChild($node) | Out-Null
+          }
+
+          Add-EnvVarIfPresent 'AdminBootstrap__Password'            $env:ADMIN_PASSWORD
+          Add-EnvVarIfPresent 'Authentication__Google__ClientId'    $env:GOOGLE_CLIENT_ID
+          Add-EnvVarIfPresent 'Authentication__Google__ClientSecret' $env:GOOGLE_CLIENT_SECRET
+          Add-EnvVarIfPresent 'Authentication__Microsoft__ClientId' $env:MICROSOFT_CLIENT_ID
+          Add-EnvVarIfPresent 'Authentication__Microsoft__ClientSecret' $env:MICROSOFT_CLIENT_SECRET
+          Add-EnvVarIfPresent 'Authentication__Facebook__AppId'     $env:FACEBOOK_APP_ID
+          Add-EnvVarIfPresent 'Authentication__Facebook__AppSecret' $env:FACEBOOK_APP_SECRET
 
           $xml.Save($webConfigPath)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,11 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Auth cookie**: 60-min expiration, sliding, HttpOnly, RequireConfirmedEmail = true
 - **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `RequireEmailConfirmed`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
 - **Claims pipeline**: `ApplicationUserClaimsPrincipalFactory` overrides `UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>` to emit custom claims at sign-in (`email_verified` from `EmailConfirmed`, `name` from `ApplicationUser.Name`). Registered via `.AddClaimsPrincipalFactory<>()` in Identity setup. The `RequireEmailConfirmed` policy consumes the `email_verified` claim.
+- **External login providers**: `AddExternalAuthentication()` extension in `Extensions/AuthenticationServiceCollectionExtensions.cs` conditionally registers Google, Microsoft, and Facebook OAuth based on configuration (Google/Microsoft use `ClientId`/`ClientSecret`; Facebook uses `AppId`/`AppSecret` matching Meta's terminology). Both keys must be present or the provider is skipped. If ClientId is empty, the provider is not added and the Login page button does not render - same code path works across dev/staging/prod. Dev config via `dotnet user-secrets`; staging config via GitHub Environment Secrets injected into `web.config` by the CD pipeline. `AccountController.ExternalLogin` / `ExternalLoginCallback` / `ExternalLoginConfirmation` handle the OAuth flow: already-linked users sign in, new users with provider-supplied email get a local account auto-created with `EmailConfirmed = true` (skipping our own email confirmation flow). Claims interop: providers emit the OIDC-standard `email_verified` claim that `ApplicationUserClaimsPrincipalFactory` also emits for local users - same name, same semantics, so `RequireEmailConfirmed` policy works unchanged for both sign-in paths.
 - **Error handling**: `ErrorController` with ServerError (500) and StatusCodeError (404/403)
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check
-- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`
+- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`, `AddExternalAuthentication()`
 
 ## Completed Features
 
@@ -36,6 +37,7 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - Bootstrap admin role/user protection (cannot delete/rename admin role, cannot lock out admin user)
 - Policy-based authorization (named policies + custom requirement/handler)
 - Custom claims pipeline (`UserClaimsPrincipalFactory` emits `email_verified`, `name`)
+- External login providers (Google, Microsoft, Facebook) with conditional registration + auto-create local user on first sign-in
 - Error handling (500, 404, 403)
 - Serilog structured logging (Console + File with daily rolling)
 - Health check endpoint at `/health`

--- a/src/AspNetCoreMvcTemplate.Web/AspNetCoreMvcTemplate.Web.csproj
+++ b/src/AspNetCoreMvcTemplate.Web/AspNetCoreMvcTemplate.Web.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">

--- a/src/AspNetCoreMvcTemplate.Web/Controllers/AccountController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using AspNetCoreMvcTemplate.Web.ViewModels.Account;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace AspNetCoreMvcTemplate.Web.Controllers
 {
@@ -215,6 +216,185 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
         public async Task<IActionResult> Logout()
         {
             await signInManager.SignOutAsync();
+            return RedirectToAction("Index", "Home");
+        }
+
+        // Start na OAuth challenge-ot. ASP.NET Core go redirektira browser-ot do
+        // Google/Microsoft, kade userot se avtentikuva. Potoa provajderot go
+        // redirektira nazad do ExternalLoginCallback.
+        [HttpPost]
+        [AllowAnonymous]
+        public IActionResult ExternalLogin(string provider, string? returnUrl = null)
+        {
+            if (string.IsNullOrWhiteSpace(provider))
+            {
+                return BadRequest("Provider not specified.");
+            }
+
+            var redirectUrl = Url.Action(nameof(ExternalLoginCallback), "Account", new { returnUrl });
+            var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
+            return Challenge(properties, provider);
+        }
+
+        // Callback koj go povikuva provajderot po uspeshen login.
+        // Tri sluchai:
+        //  1. User-ot vekje go linkuval ovoj provajder -> sign-in
+        //  2. Nov user, provajderot prakja email claim -> avtomatski kreiraj lokalen user
+        //     so EmailConfirmed = true (provajderot go potvrdil emailot)
+        //  3. Nov user bez email claim -> redirektiraj na formata za potvrda
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> ExternalLoginCallback(string? returnUrl = null, string? remoteError = null)
+        {
+            if (remoteError != null)
+            {
+                // Detalen error e zapishan samo vo log; korisnikot dobiva generichka poraka
+                // za da ne se leakne interna informacija od provajderot vo UI.
+                logger.LogWarning("External provider returned error: {Error}", remoteError);
+                ModelState.AddModelError(string.Empty, "External login failed. Please try again.");
+                return View(nameof(Login), new LoginViewModel { ReturnUrl = returnUrl });
+            }
+
+            var info = await signInManager.GetExternalLoginInfoAsync();
+            if (info is null)
+            {
+                logger.LogWarning("GetExternalLoginInfoAsync returned null; external login context lost.");
+                return RedirectToAction(nameof(Login), new { returnUrl });
+            }
+
+            // Sluchai 1: vekje linkuval - sign in.
+            // bypassTwoFactor: true e default-ot na Microsoft Identity scaffoldot. Vo
+            // ovoj template 2FA ne e implementiran, taka shto vrednosta nema efekt.
+            // Koga kje se dodade 2FA branch, treba da se prefrli na false i da se
+            // dodade LoginWith2fa action za da se zavrshi 2FA flow-ot.
+            var signInResult = await signInManager.ExternalLoginSignInAsync(
+                info.LoginProvider,
+                info.ProviderKey,
+                isPersistent: false,
+                bypassTwoFactor: true);
+
+            if (signInResult.Succeeded)
+            {
+                logger.LogInformation(
+                    "User signed in via {Provider} (ProviderKey: {ProviderKey}).",
+                    info.LoginProvider,
+                    info.ProviderKey);
+                return RedirectToLocal(returnUrl);
+            }
+
+            if (signInResult.IsLockedOut)
+            {
+                return RedirectToAction(nameof(Lockout));
+            }
+
+            // Sluchai 2 ili 3: prv pat login so ovoj provajder za ovoj user.
+            var email = info.Principal.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+
+            if (string.IsNullOrEmpty(email))
+            {
+                // Sluchaj 3: provajderot ne dal email - pokazi forma za vnesuvanje
+                var model = new ExternalLoginConfirmationViewModel
+                {
+                    ReturnUrl = returnUrl,
+                    ProviderDisplayName = info.ProviderDisplayName
+                };
+                return View(nameof(ExternalLoginConfirmation), model);
+            }
+
+            // Sluchaj 2: imame email od provajderot, avtomatski kreiraj user.
+            return await CreateExternalUserAndSignInAsync(info, email, returnUrl);
+        }
+
+        // Fallback za Sluchaj 3 - userot rachno vnese email.
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> ExternalLoginConfirmation(ExternalLoginConfirmationViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var info = await signInManager.GetExternalLoginInfoAsync();
+            if (info is null)
+            {
+                logger.LogWarning("ExternalLoginConfirmation: external login info was lost.");
+                return RedirectToAction(nameof(Login));
+            }
+
+            return await CreateExternalUserAndSignInAsync(info, model.Email, model.ReturnUrl);
+        }
+
+        private async Task<IActionResult> CreateExternalUserAndSignInAsync(
+            ExternalLoginInfo info,
+            string email,
+            string? returnUrl)
+        {
+            var existingUser = await userManager.FindByEmailAsync(email);
+            if (existingUser is not null)
+            {
+                // Postoi lokalen user so ovoj email no ne e linkuvan so ovoj provajder.
+                // Za bezbednost ne dozvoluvame avtomatsko linkuvanje - userot mora
+                // prvo da se najavi so password pa da go linkuva od profilot.
+                logger.LogInformation(
+                    "External login with existing email {Email} but no link. User must link from profile.",
+                    email);
+
+                ModelState.AddModelError(string.Empty,
+                    "An account with this email already exists. Please sign in with your password first and link the external provider from your profile.");
+                return View(nameof(Login), new LoginViewModel { Email = email, ReturnUrl = returnUrl });
+            }
+
+            // name claim e korisno da se zadrzi ako provajderot go dal
+            var name =
+            info.Principal.FindFirst(ClaimTypes.GivenName)?.Value
+            ?? info.Principal.FindFirst(ClaimTypes.Name)?.Value
+            ?? email;
+
+            var newUser = new ApplicationUser
+            {
+                UserName = email,
+                Email = email,
+                Name = name,
+                EmailConfirmed = true // provajderot ja potvrdil email adresata
+            };
+
+            var createResult = await userManager.CreateAsync(newUser);
+            if (!createResult.Succeeded)
+            {
+                foreach (var error in createResult.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                return View(nameof(Login), new LoginViewModel { Email = email, ReturnUrl = returnUrl });
+            }
+
+            var linkResult = await userManager.AddLoginAsync(newUser, info);
+            if (!linkResult.Succeeded)
+            {
+                logger.LogError(
+                    "Failed to link external login for {Email}: {Errors}",
+                    email,
+                    string.Join("; ", linkResult.Errors.Select(e => e.Description)));
+
+                foreach (var error in linkResult.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+                return View(nameof(Login), new LoginViewModel { Email = email, ReturnUrl = returnUrl });
+            }
+
+            await signInManager.SignInAsync(newUser, isPersistent: false);
+            logger.LogInformation("Created local user {Email} from external provider {Provider}.", email, info.LoginProvider);
+            return RedirectToLocal(returnUrl);
+        }
+
+        private IActionResult RedirectToLocal(string? returnUrl)
+        {
+            if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
+            {
+                return Redirect(returnUrl);
+            }
             return RedirectToAction("Index", "Home");
         }
 

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/AuthenticationServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/AuthenticationServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+namespace AspNetCoreMvcTemplate.Web.Extensions
+{
+    // Registrira eksterni login provajderi (Google, Microsoft) samo ako e
+    // postaven ClientId vo konfiguracijata. Na razvoj ClientId doaga od user-secrets,
+    // na staging/prod doaga od environment variable (injektiran od CD pipeline vo web.config).
+    //
+    // Ako ClientId e prazen - provajderot ne e registriran, butonot na Login stranata
+    // ne se prikazuva, aplikacijata ne crash-nuva. Istata ovaa logika raboti niz site okruzhuvanja.
+    public static class AuthenticationServiceCollectionExtensions
+    {
+        public static IServiceCollection AddExternalAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            var authBuilder = services.AddAuthentication();
+
+            // Bara i ClientId i ClientSecret. Ako samo eden e prisuten, provajderot
+            // ke crashne pri token exchange - po-dobro e voopsho da ne go registrirame.
+            var googleClientId = configuration["Authentication:Google:ClientId"];
+            var googleClientSecret = configuration["Authentication:Google:ClientSecret"];
+            if (!string.IsNullOrWhiteSpace(googleClientId)
+                && !string.IsNullOrWhiteSpace(googleClientSecret))
+            {
+                authBuilder.AddGoogle(options =>
+                {
+                    options.ClientId = googleClientId;
+                    options.ClientSecret = googleClientSecret;
+                    // Google vrakja email_verified claim direktno od id_tokenot.
+                    // Avtomatski se mapira na ClaimsPrincipal - nema dopolnitelna konfiguracija.
+                });
+            }
+
+            var microsoftClientId = configuration["Authentication:Microsoft:ClientId"];
+            var microsoftClientSecret = configuration["Authentication:Microsoft:ClientSecret"];
+            if (!string.IsNullOrWhiteSpace(microsoftClientId)
+                && !string.IsNullOrWhiteSpace(microsoftClientSecret))
+            {
+                authBuilder.AddMicrosoftAccount(options =>
+                {
+                    options.ClientId = microsoftClientId;
+                    options.ClientSecret = microsoftClientSecret;
+                });
+            }
+
+            // Facebook koristi AppId/AppSecret terminologija (kako vo Meta for Developers
+            // konzolata) - po internoto se mapira na ClientId/ClientSecret. Facebook
+            // garantira deka site emails se verificirani, taka shto novite useri se
+            // kreiraat so EmailConfirmed = true (isto kako Google).
+            var facebookAppId = configuration["Authentication:Facebook:AppId"];
+            var facebookAppSecret = configuration["Authentication:Facebook:AppSecret"];
+            if (!string.IsNullOrWhiteSpace(facebookAppId)
+                && !string.IsNullOrWhiteSpace(facebookAppSecret))
+            {
+                authBuilder.AddFacebook(options =>
+                {
+                    options.AppId = facebookAppId;
+                    options.AppSecret = facebookAppSecret;
+                });
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Program.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Program.cs
@@ -56,6 +56,8 @@ namespace AspNetCoreMvcTemplate.Web
 
             builder.Services.AddAuthorizationPolicies();
 
+            builder.Services.AddExternalAuthentication(builder.Configuration);
+
             builder.Services.ConfigureApplicationCookie(options =>
             {
                 options.LoginPath = "/Account/Login";

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Account/ExternalLoginConfirmationViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Account/ExternalLoginConfirmationViewModel.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Account
+{
+    public class ExternalLoginConfirmationViewModel
+    {
+        [Required]
+        [EmailAddress]
+        [StringLength(256)]
+        [Display(Name = "Email")]
+        public string Email { get; set; } = string.Empty;
+
+        public string? ReturnUrl { get; set; }
+
+        // Ime na provajderot, samo za prikaz vo view-ot.
+        public string? ProviderDisplayName { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Account/ExternalLoginConfirmation.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Account/ExternalLoginConfirmation.cshtml
@@ -1,0 +1,32 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Account
+@model ExternalLoginConfirmationViewModel
+
+@{
+    ViewData["Title"] = "Confirm external login";
+}
+
+<h1>Associate your @Model.ProviderDisplayName account</h1>
+
+<p class="text-muted">
+    We could not read an email address from @Model.ProviderDisplayName. Please enter
+    the email you would like to use for your account.
+</p>
+
+<form asp-action="ExternalLoginConfirmation" method="post">
+    <input asp-for="ReturnUrl" type="hidden" />
+    <input asp-for="ProviderDisplayName" type="hidden" />
+
+    <div asp-validation-summary="All" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Account/Login.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Account/Login.cshtml
@@ -1,49 +1,80 @@
-﻿@using AspNetCoreMvcTemplate.Web.ViewModels.Account
+@using AspNetCoreMvcTemplate.Web.ViewModels.Account
+@using AspNetCoreMvcTemplate.Web.Models.Identity
+@using Microsoft.AspNetCore.Identity
+@inject SignInManager<ApplicationUser> SignInManager
 @model LoginViewModel
 
 @{
     ViewData["Title"] = "Login";
+    // Prikazuva se samo onie provajderi koi se registrirani vo Program.cs
+    // preku AddExternalAuthentication(). Ako ClientId ne e konfiguriran,
+    // provajderot voopshto nema da se pojavi tuka.
+    var externalSchemes = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToList();
 }
 
 <h1>Login</h1>
 
-<form asp-action="Login" method="post">
-    <input asp-for="ReturnUrl" type="hidden" />
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Login" method="post">
+            <input asp-for="ReturnUrl" type="hidden" />
 
-    <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Email" class="form-label"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
+            <div class="mb-3">
+                <label asp-for="Email" class="form-label"></label>
+                <input asp-for="Email" class="form-control" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Password" class="form-label"></label>
+                <input asp-for="Password" class="form-control" />
+                <span asp-validation-for="Password" class="text-danger"></span>
+            </div>
+
+            <div class="form-check mb-3">
+                <input asp-for="RememberMe" class="form-check-input" />
+                <label asp-for="RememberMe" class="form-check-label"></label>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Login</button>
+        </form>
+
+        <p class="mt-3">
+            <a asp-action="ForgotPassword">Forgot your password?</a>
+        </p>
+
+        @if (ViewBag.ShowResendConfirmationLink == true)
+        {
+            <p>
+                <a asp-action="ResendConfirmationEmail" asp-route-email="@Model.Email">
+                    Resend confirmation email
+                </a>
+            </p>
+        }
     </div>
 
-    <div class="mb-3">
-        <label asp-for="Password" class="form-label"></label>
-        <input asp-for="Password" class="form-control" />
-        <span asp-validation-for="Password" class="text-danger"></span>
-    </div>
-
-    <div class="form-check mb-3">
-        <input asp-for="RememberMe" class="form-check-input" />
-        <label asp-for="RememberMe" class="form-check-label"></label>
-    </div>
-
-    <button type="submit" class="btn btn-primary">Login</button>
-</form>
-
-<p class="mt-3">
-    <a asp-action="ForgotPassword">Forgot your password?</a>
-</p>
-
-@if (ViewBag.ShowResendConfirmationLink == true)
-{
-    <p>
-        <a asp-action="ResendConfirmationEmail" asp-route-email="@Model.Email">
-            Resend confirmation email
-        </a>
-    </p>
-}
+    @if (externalSchemes.Count > 0)
+    {
+        <div class="col-md-6">
+            <h4>Or sign in with</h4>
+            <form asp-action="ExternalLogin" method="post">
+                <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
+                @foreach (var scheme in externalSchemes)
+                {
+                    <button type="submit"
+                            class="btn btn-outline-secondary me-2 mb-2"
+                            name="provider"
+                            value="@scheme.Name"
+                            title="Log in using @scheme.DisplayName">
+                        @scheme.DisplayName
+                    </button>
+                }
+            </form>
+        </div>
+    }
+</div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/src/AspNetCoreMvcTemplate.Web/appsettings.json
+++ b/src/AspNetCoreMvcTemplate.Web/appsettings.json
@@ -40,5 +40,19 @@
   },
   "DataProtection": {
     "KeysPath": "D:\\Sites\\AspNetCoreMvcTemplate\\keys"
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Microsoft": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Facebook": {
+      "AppId": "",
+      "AppSecret": ""
+    }
   }
 }

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerExternalLoginTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerExternalLoginTests.cs
@@ -1,0 +1,244 @@
+using System.Security.Claims;
+using AspNetCoreMvcTemplate.Emailing.Abstractions;
+using AspNetCoreMvcTemplate.Web.Controllers;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.ViewModels.Account;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Controllers;
+
+public class AccountControllerExternalLoginTests
+{
+    [Fact]
+    public async Task ExternalLoginCallback_ReturnsLoginView_WhenRemoteErrorIsPresent()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ExternalLoginCallback(returnUrl: null, remoteError: "access_denied");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Equal(nameof(AccountController.Login), viewResult.ViewName);
+        Assert.False(controller.ModelState.IsValid);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_RedirectsToLogin_WhenExternalLoginInfoIsNull()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        signInManager
+            .Setup(x => x.GetExternalLoginInfoAsync(null))
+            .ReturnsAsync((ExternalLoginInfo?)null);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ExternalLoginCallback();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(AccountController.Login), redirect.ActionName);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_RedirectsHome_WhenUserAlreadyLinked()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var info = CreateExternalLoginInfo("user@test.com", "Test User", provider: "Google");
+
+        signInManager
+            .Setup(x => x.GetExternalLoginInfoAsync(null))
+            .ReturnsAsync(info);
+
+        signInManager
+            .Setup(x => x.ExternalLoginSignInAsync("Google", "provider-key", false, true))
+            .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ExternalLoginCallback();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Home", redirect.ControllerName);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_CreatesUserWithEmailConfirmedTrue_WhenProviderReturnsEmail()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var info = CreateExternalLoginInfo("new@test.com", "New User", provider: "Google");
+
+        signInManager
+            .Setup(x => x.GetExternalLoginInfoAsync(null))
+            .ReturnsAsync(info);
+
+        signInManager
+            .Setup(x => x.ExternalLoginSignInAsync("Google", "provider-key", false, true))
+            .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+        userManager
+            .Setup(x => x.FindByEmailAsync("new@test.com"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        ApplicationUser? createdUser = null;
+        userManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>()))
+            .Callback<ApplicationUser>(u => createdUser = u)
+            .ReturnsAsync(IdentityResult.Success);
+
+        userManager
+            .Setup(x => x.AddLoginAsync(It.IsAny<ApplicationUser>(), info))
+            .ReturnsAsync(IdentityResult.Success);
+
+        signInManager
+            .Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), false, null))
+            .Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ExternalLoginCallback();
+
+        Assert.NotNull(createdUser);
+        Assert.Equal("new@test.com", createdUser!.Email);
+        Assert.True(createdUser.EmailConfirmed);
+        Assert.Equal("New User", createdUser.Name);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Home", redirect.ControllerName);
+    }
+
+    [Fact]
+    public async Task ExternalLoginConfirmation_Post_CreatesUserAndSignsIn_WhenValid()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var info = CreateExternalLoginInfo(email: null, name: null, provider: "Microsoft");
+
+        signInManager
+            .Setup(x => x.GetExternalLoginInfoAsync(null))
+            .ReturnsAsync(info);
+
+        userManager
+            .Setup(x => x.FindByEmailAsync("manual@test.com"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        ApplicationUser? createdUser = null;
+        userManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>()))
+            .Callback<ApplicationUser>(u => createdUser = u)
+            .ReturnsAsync(IdentityResult.Success);
+
+        userManager
+            .Setup(x => x.AddLoginAsync(It.IsAny<ApplicationUser>(), info))
+            .ReturnsAsync(IdentityResult.Success);
+
+        signInManager
+            .Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), false, null))
+            .Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var model = new ExternalLoginConfirmationViewModel
+        {
+            Email = "manual@test.com"
+        };
+
+        var result = await controller.ExternalLoginConfirmation(model);
+
+        Assert.NotNull(createdUser);
+        Assert.Equal("manual@test.com", createdUser!.Email);
+        Assert.True(createdUser.EmailConfirmed);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Home", redirect.ControllerName);
+    }
+
+    private static ExternalLoginInfo CreateExternalLoginInfo(string? email, string? name, string provider)
+    {
+        var claims = new List<Claim>();
+        if (!string.IsNullOrEmpty(email))
+        {
+            claims.Add(new Claim(ClaimTypes.Email, email));
+        }
+        if (!string.IsNullOrEmpty(name))
+        {
+            claims.Add(new Claim(ClaimTypes.Name, name));
+        }
+
+        var identity = new ClaimsIdentity(claims, provider);
+        var principal = new ClaimsPrincipal(identity);
+
+        return new ExternalLoginInfo(principal, provider, "provider-key", provider);
+    }
+
+    private static AccountController CreateController(
+        UserManager<ApplicationUser> userManager,
+        SignInManager<ApplicationUser> signInManager,
+        IEmailSender emailSender)
+    {
+        var controller = new AccountController(
+            userManager,
+            signInManager,
+            emailSender,
+            NullLogger<AccountController>.Instance);
+
+        // URL helper e potreben za Url.Action i Url.IsLocalUrl vo actionite.
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(x => x.IsLocalUrl(It.IsAny<string>())).Returns(false);
+        urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns("/Account/ExternalLoginCallback");
+        controller.Url = urlHelper.Object;
+
+        return controller;
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<SignInManager<ApplicationUser>> CreateSignInManagerMock(UserManager<ApplicationUser> userManager)
+    {
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();
+
+        return new Mock<SignInManager<ApplicationUser>>(
+            userManager,
+            contextAccessor.Object,
+            claimsFactory.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Extensions/AuthenticationServiceCollectionExtensionsTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Extensions/AuthenticationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,86 @@
+using AspNetCoreMvcTemplate.Web.Extensions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Extensions;
+
+public class AuthenticationServiceCollectionExtensionsTests
+{
+    [Fact]
+    public async Task AddExternalAuthentication_DoesNotRegisterProviders_WhenClientIdsAreEmpty()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Google:ClientId"] = "",
+                ["Authentication:Microsoft:ClientId"] = ""
+            })
+            .Build();
+
+        services.AddExternalAuthentication(configuration);
+        var provider = services.BuildServiceProvider();
+
+        var schemeProvider = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+        var schemes = await schemeProvider.GetAllSchemesAsync();
+
+        Assert.DoesNotContain(schemes, s => s.Name == "Google");
+        Assert.DoesNotContain(schemes, s => s.Name == "Microsoft");
+    }
+
+    [Fact]
+    public async Task AddExternalAuthentication_DoesNotRegisterProvider_WhenClientSecretIsMissing()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // ClientId e postaven ama ClientSecret e prazen - provajderot ke crashne
+        // pri token exchange, zatoa voopshto ne go registrirame.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Google:ClientId"] = "google-test-id",
+                ["Authentication:Google:ClientSecret"] = "",
+                ["Authentication:Microsoft:ClientId"] = "microsoft-test-id"
+            })
+            .Build();
+
+        services.AddExternalAuthentication(configuration);
+        var provider = services.BuildServiceProvider();
+
+        var schemeProvider = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+        var schemes = await schemeProvider.GetAllSchemesAsync();
+
+        Assert.DoesNotContain(schemes, s => s.Name == "Google");
+        Assert.DoesNotContain(schemes, s => s.Name == "Microsoft");
+    }
+
+    [Fact]
+    public async Task AddExternalAuthentication_RegistersProviders_WhenClientIdsAreConfigured()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Google:ClientId"] = "google-test-id",
+                ["Authentication:Google:ClientSecret"] = "google-test-secret",
+                ["Authentication:Microsoft:ClientId"] = "microsoft-test-id",
+                ["Authentication:Microsoft:ClientSecret"] = "microsoft-test-secret"
+            })
+            .Build();
+
+        services.AddExternalAuthentication(configuration);
+        var provider = services.BuildServiceProvider();
+
+        var schemeProvider = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+        var schemes = await schemeProvider.GetAllSchemesAsync();
+
+        Assert.Contains(schemes, s => s.Name == "Google");
+        Assert.Contains(schemes, s => s.Name == "Microsoft");
+    }
+}


### PR DESCRIPTION
Summary

Adds external authentication provider support to the MVC template using ASP.NET Core Identity external login flow.

This introduces provider-agnostic external authentication with dynamic provider rendering, external account provisioning, and safe duplicate-account handling.

What changed
Authentication
Added external authentication provider registration extension
Registered providers conditionally based on configured credentials
Added support for:
Google
Facebook
Microsoft (optional / configuration-ready)
Account flow
Added external login challenge flow
Added external login callback handling
Added external login confirmation fallback for providers without email
Added local account provisioning for first-time external users
Marked externally provisioned users as EmailConfirmed = true
Prevented unsafe auto-linking when local account already exists
UI
Updated Login view to render configured external providers dynamically
Added external login confirmation view for email fallback flow
Configuration
Added external auth placeholders in appsettings.json
Added provider package references
Wired external auth registration in Program.cs
Deployment
Extended IIS deployment workflow to inject external provider secrets into web.config
Added reusable secret injection helper for optional environment variables
Tests
Added controller tests covering:
provider error handling
missing external login context
existing linked login sign-in
new external user auto-provisioning
manual confirmation fallback
Added registration tests covering conditional provider registration
Notes
Existing local accounts are intentionally not auto-linked by matching email
External provider linking from profile is intentionally deferred to a follow-up branch
Microsoft provider is wired and ready but intentionally optional until credentials are configured