### PR TITLE
Add self-service user profile management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Admin area**: MVC Area at `Areas/Admin/` with Dashboard, Roles CRUD, Users management
 - **Role management**: RolesController — create, rename, delete roles. Bootstrap admin role is protected.
 - **User management**: UsersController — edit user (Name, EmailConfirmed, LockoutEnabled), assign/unassign roles via checkbox list. Bootstrap admin user is protected.
+- **User profile**: `ProfileController` (self-service, `[Authorize]`) — view profile, change name / password / email, set password (for users without one — e.g. external-only sign-up), manage linked external logins. Email change uses a confirmation token sent to the *new* address; on confirmation, both `Email` and `UserName` are updated together so password sign-in still works. After mutating actions `signInManager.RefreshSignInAsync(user)` is called so the cookie's claims (`name`, `email_verified`) re-emit fresh values without forcing a full re-login. Linking flow: `LinkLogin` kicks off OAuth challenge tagged with the user id; `LinkLoginCallback` reads the info via `GetExternalLoginInfoAsync(userId)` and calls `userManager.AddLoginAsync`. Unlinking has an orphan-prevention guard: refuses to remove the only sign-in method (no password AND no other external logins).
 - **Auth cookie**: 60-min expiration, sliding, HttpOnly, RequireConfirmedEmail = true
 - **Authorization policies**: `Authorization/` folder with `AuthorizationPolicies` constants (`AdminOnly`, `RequireEmailConfirmed`, `ActiveUser`). Admin controllers use `[Authorize(Policy = AuthorizationPolicies.AdminOnly)]`. Custom `ActiveUserRequirement` + `ActiveUserAuthorizationHandler` demonstrates the requirement/handler pattern with `UserManager` injection.
 - **Claims pipeline**: `ApplicationUserClaimsPrincipalFactory` overrides `UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>` to emit custom claims at sign-in (`email_verified` from `EmailConfirmed`, `name` from `ApplicationUser.Name`). Registered via `.AddClaimsPrincipalFactory<>()` in Identity setup. The `RequireEmailConfirmed` policy consumes the `email_verified` claim.
@@ -38,13 +39,14 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - Policy-based authorization (named policies + custom requirement/handler)
 - Custom claims pipeline (`UserClaimsPrincipalFactory` emits `email_verified`, `name`)
 - External login providers (Google, Microsoft, Facebook) with conditional registration + auto-create local user on first sign-in
+- Self-service user profile: change name / password / email (with confirmation), set password for external-only users, link/unlink external providers (with orphan-prevention guard)
 - Error handling (500, 404, 403)
 - Serilog structured logging (Console + File with daily rolling)
 - Health check endpoint at `/health`
 - GitHub Actions CI (build + test)
 - GitHub Actions CD (IIS deployment to staging)
 - Data protection keys persisted to file system
-- 53+ unit and integration tests
+- 66+ unit and integration tests
 
 ## Branching
 

--- a/src/AspNetCoreMvcTemplate.Web/Controllers/ProfileController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Controllers/ProfileController.cs
@@ -1,0 +1,439 @@
+using AspNetCoreMvcTemplate.Emailing.Abstractions;
+using AspNetCoreMvcTemplate.Emailing.Models;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.ViewModels.Profile;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreMvcTemplate.Web.Controllers
+{
+    // Self-service profile actions. Site dejstva baraat avtenticiran user.
+    [Authorize]
+    [AutoValidateAntiforgeryToken]
+    public class ProfileController : Controller
+    {
+        private readonly UserManager<ApplicationUser> userManager;
+        private readonly SignInManager<ApplicationUser> signInManager;
+        private readonly IEmailSender emailSender;
+        private readonly ILogger<ProfileController> logger;
+
+        public ProfileController(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            IEmailSender emailSender,
+            ILogger<ProfileController> logger)
+        {
+            this.userManager = userManager;
+            this.signInManager = signInManager;
+            this.emailSender = emailSender;
+            this.logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            var currentLogins = await userManager.GetLoginsAsync(user);
+            var allSchemes = await signInManager.GetExternalAuthenticationSchemesAsync();
+
+            // Provajderi koi se konfigurirani vo aplikacijata, no ne se ushte
+            // povrzani so ovoj user - tie se kandidati za "Link" butonot.
+            var availableProviders = allSchemes
+                .Where(s => currentLogins.All(l => l.LoginProvider != s.Name))
+                .ToList();
+
+            var model = new ProfileIndexViewModel
+            {
+                Name = user.Name,
+                Email = user.Email ?? string.Empty,
+                EmailConfirmed = user.EmailConfirmed,
+                HasPassword = await userManager.HasPasswordAsync(user),
+                CurrentLogins = currentLogins,
+                AvailableProviders = availableProviders,
+                StatusMessage = TempData["StatusMessage"] as string
+            };
+
+            return View(model);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ChangeName()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            return View(new ChangeNameViewModel { Name = user.Name });
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ChangeName(ChangeNameViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            user.Name = model.Name;
+            var result = await userManager.UpdateAsync(user);
+            if (!result.Succeeded)
+            {
+                AddIdentityErrors(result);
+                return View(model);
+            }
+
+            // Refresh za da se obnovi `name` claim-ot vo cookie-to (factory-to go emituva).
+            await signInManager.RefreshSignInAsync(user);
+            logger.LogInformation("User {Email} changed their name.", user.Email);
+
+            TempData["StatusMessage"] = "Your name has been updated.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ChangePassword()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            // Useri bez lokalen password odat na SetPassword.
+            if (!await userManager.HasPasswordAsync(user))
+            {
+                return RedirectToAction(nameof(SetPassword));
+            }
+
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ChangePassword(ChangePasswordViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            var result = await userManager.ChangePasswordAsync(user, model.CurrentPassword, model.NewPassword);
+            if (!result.Succeeded)
+            {
+                AddIdentityErrors(result);
+                return View(model);
+            }
+
+            await signInManager.RefreshSignInAsync(user);
+            logger.LogInformation("User {Email} changed their password.", user.Email);
+
+            TempData["StatusMessage"] = "Your password has been changed.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> SetPassword()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            // Ako vekje ima lozinka, kanal e ChangePassword - ne SetPassword.
+            if (await userManager.HasPasswordAsync(user))
+            {
+                return RedirectToAction(nameof(ChangePassword));
+            }
+
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> SetPassword(SetPasswordViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            if (await userManager.HasPasswordAsync(user))
+            {
+                // Race-condition guard - nekoj drug tab vekje postavil lozinka.
+                return RedirectToAction(nameof(ChangePassword));
+            }
+
+            var result = await userManager.AddPasswordAsync(user, model.NewPassword);
+            if (!result.Succeeded)
+            {
+                AddIdentityErrors(result);
+                return View(model);
+            }
+
+            await signInManager.RefreshSignInAsync(user);
+            logger.LogInformation("User {Email} set a local password.", user.Email);
+
+            TempData["StatusMessage"] = "Your password has been set. You can now sign in with your email and password.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ChangeEmail()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            return View(new ChangeEmailViewModel { CurrentEmail = user.Email ?? string.Empty });
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ChangeEmail(ChangeEmailViewModel model)
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            // Vrakjame current email vo modelot za da go ima vo view-ot pri error.
+            model.CurrentEmail = user.Email ?? string.Empty;
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            if (string.Equals(model.NewEmail, user.Email, StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(nameof(model.NewEmail), "The new email is the same as your current email.");
+                return View(model);
+            }
+
+            // Tokenot se generira so noviot email kako payload.
+            var token = await userManager.GenerateChangeEmailTokenAsync(user, model.NewEmail);
+
+            var confirmationLink = Url.Action(
+                nameof(ConfirmEmailChange),
+                "Profile",
+                new { userId = user.Id, newEmail = model.NewEmail, token },
+                Request.Scheme);
+
+            if (confirmationLink is null)
+            {
+                logger.LogError("Failed to generate change-email link for user {Email}.", user.Email);
+                ModelState.AddModelError(string.Empty, "Unable to generate the confirmation link.");
+                return View(model);
+            }
+
+            var sendResult = await emailSender.SendAsync(new EmailMessage
+            {
+                To = model.NewEmail,
+                Subject = "Confirm your new email",
+                HtmlBody = $"""
+                    <p>Hello {user.Name},</p>
+                    <p>Please confirm your new email address by clicking the link below:</p>
+                    <p><a href="{confirmationLink}">Confirm new email</a></p>
+                    <p>If you did not request this change, you can ignore this message.</p>
+                    """
+            });
+
+            if (!sendResult.Succeeded)
+            {
+                logger.LogError("Failed to send change-email confirmation to {NewEmail}. Error: {Error}",
+                    model.NewEmail,
+                    sendResult.ErrorMessage);
+                ModelState.AddModelError(string.Empty, "We could not send the confirmation email right now. Please try again.");
+                return View(model);
+            }
+
+            logger.LogInformation("Change-email confirmation sent for user {OldEmail} -> {NewEmail}.", user.Email, model.NewEmail);
+
+            TempData["StatusMessage"] = $"A confirmation link has been sent to {model.NewEmail}. Click it to complete the change.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ConfirmEmailChange(string userId, string newEmail, string token)
+        {
+            if (string.IsNullOrWhiteSpace(userId)
+                || string.IsNullOrWhiteSpace(newEmail)
+                || string.IsNullOrWhiteSpace(token))
+            {
+                return View("Error");
+            }
+
+            var user = await userManager.FindByIdAsync(userId);
+            if (user is null)
+            {
+                logger.LogWarning("ConfirmEmailChange failed because user {UserId} was not found.", userId);
+                return View("Error");
+            }
+
+            var changeResult = await userManager.ChangeEmailAsync(user, newEmail, token);
+            if (!changeResult.Succeeded)
+            {
+                logger.LogWarning("ChangeEmailAsync failed for user {UserId}.", userId);
+                return View("Error");
+            }
+
+            // UserName mora da se sinhronizira so noviot email - inaku PasswordSignInAsync
+            // (koja koristi UserName) ke pravi mismatch i userot ne moze da se najavi
+            // so noviot email.
+            var setUserNameResult = await userManager.SetUserNameAsync(user, newEmail);
+            if (!setUserNameResult.Succeeded)
+            {
+                logger.LogError("SetUserNameAsync failed after email change for user {UserId}.", userId);
+                return View("Error");
+            }
+
+            await signInManager.RefreshSignInAsync(user);
+            logger.LogInformation("Email changed successfully for user {UserId} to {NewEmail}.", userId, newEmail);
+
+            TempData["StatusMessage"] = "Your email has been updated.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        // start na OAuth flow-ot za povrzuvanje na ekstern provajder
+        // so vekje avtenticiran user.
+        [HttpPost]
+        public async Task<IActionResult> LinkLogin(string provider)
+        {
+            if (string.IsNullOrWhiteSpace(provider))
+            {
+                return BadRequest("Provider not specified.");
+            }
+
+            // Ja chistime postojnata external cookie za da ne se izmesa so
+            // novo-stignatite informacii od provajderot.
+            await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+            var redirectUrl = Url.Action(nameof(LinkLoginCallback), "Profile");
+            var userId = userManager.GetUserId(User);
+            var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl, userId);
+
+            return Challenge(properties, provider);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> LinkLoginCallback(string? remoteError = null)
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            // OnRemoteFailure (vidi AuthenticationServiceCollectionExtensions) gi konvertira
+            // OAuth cancel/error vo ovoj query param namesto unhandled exception.
+            if (remoteError != null)
+            {
+                logger.LogInformation("LinkLogin cancelled or failed for user {UserId}: {Error}", user.Id, remoteError);
+                TempData["StatusMessage"] = "Linking was cancelled or failed. Please try again.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            // Vazno: predavame userId - taka GetExternalLoginInfoAsync go zema
+            // vlezniot kontekst za toj specifichen user.
+            var info = await signInManager.GetExternalLoginInfoAsync(user.Id);
+            if (info is null)
+            {
+                logger.LogWarning("LinkLoginCallback: external login info was lost for user {UserId}.", user.Id);
+                TempData["StatusMessage"] = "Could not link the external account. Please try again.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            var result = await userManager.AddLoginAsync(user, info);
+            if (!result.Succeeded)
+            {
+                logger.LogWarning("AddLoginAsync failed for user {UserId} provider {Provider}.", user.Id, info.LoginProvider);
+                TempData["StatusMessage"] = "Could not link the external account. It may already be linked to another user.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            // Cleanup - zatvori ja external cookie-to koja ja koristevme samo za linking.
+            await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+            logger.LogInformation("User {UserId} linked external provider {Provider}.", user.Id, info.LoginProvider);
+            TempData["StatusMessage"] = $"The {info.ProviderDisplayName} account has been linked.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> RemoveLogin(string loginProvider, string providerKey)
+        {
+            if (string.IsNullOrWhiteSpace(loginProvider) || string.IsNullOrWhiteSpace(providerKey))
+            {
+                return BadRequest();
+            }
+
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            // Orphan-prevention: userot ne smee da ostane bez nachin za sign-in.
+            // Mora da ima ili lozinka ili barem ushte eden ekstern provajder.
+            var hasPassword = await userManager.HasPasswordAsync(user);
+            var otherLogins = (await userManager.GetLoginsAsync(user))
+                .Count(l => l.LoginProvider != loginProvider);
+
+            if (!hasPassword && otherLogins == 0)
+            {
+                TempData["StatusMessage"] = "You must set a password or link another provider before unlinking your only sign-in method.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            var result = await userManager.RemoveLoginAsync(user, loginProvider, providerKey);
+            if (!result.Succeeded)
+            {
+                logger.LogWarning("RemoveLoginAsync failed for user {UserId} provider {Provider}.", user.Id, loginProvider);
+                TempData["StatusMessage"] = "Could not unlink the external account.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            await signInManager.RefreshSignInAsync(user);
+            logger.LogInformation("User {UserId} unlinked external provider {Provider}.", user.Id, loginProvider);
+
+            TempData["StatusMessage"] = $"The {loginProvider} account has been unlinked.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        private void AddIdentityErrors(IdentityResult result)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/AuthenticationServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/AuthenticationServiceCollectionExtensions.cs
@@ -1,11 +1,14 @@
+using Microsoft.AspNetCore.Authentication;
+
 namespace AspNetCoreMvcTemplate.Web.Extensions
 {
-    // Registrira eksterni login provajderi (Google, Microsoft) samo ako e
-    // postaven ClientId vo konfiguracijata. Na razvoj ClientId doaga od user-secrets,
-    // na staging/prod doaga od environment variable (injektiran od CD pipeline vo web.config).
+    // Registrira eksterni login provajderi (Google, Microsoft, Facebook) samo ako se
+    // postaveni i ClientId i ClientSecret (resp. AppId / AppSecret za Facebook) vo
+    // konfiguracijata. Na razvoj idat od user-secrets, na staging/prod od environment
+    // variable injektirani od CD pipeline vo web.config.
     //
-    // Ako ClientId e prazen - provajderot ne e registriran, butonot na Login stranata
-    // ne se prikazuva, aplikacijata ne crash-nuva. Istata ovaa logika raboti niz site okruzhuvanja.
+    // Ako keys ne se postaveni - provajderot ne se registrira, butonot na Login stranata
+    // ne se prikazuva, aplikacijata ne crash-nuva. Istata logika raboti niz site okruzhuvanja.
     public static class AuthenticationServiceCollectionExtensions
     {
         public static IServiceCollection AddExternalAuthentication(
@@ -27,6 +30,7 @@ namespace AspNetCoreMvcTemplate.Web.Extensions
                     options.ClientSecret = googleClientSecret;
                     // Google vrakja email_verified claim direktno od id_tokenot.
                     // Avtomatski se mapira na ClaimsPrincipal - nema dopolnitelna konfiguracija.
+                    options.Events.OnRemoteFailure = HandleRemoteFailure;
                 });
             }
 
@@ -39,6 +43,7 @@ namespace AspNetCoreMvcTemplate.Web.Extensions
                 {
                     options.ClientId = microsoftClientId;
                     options.ClientSecret = microsoftClientSecret;
+                    options.Events.OnRemoteFailure = HandleRemoteFailure;
                 });
             }
 
@@ -55,10 +60,28 @@ namespace AspNetCoreMvcTemplate.Web.Extensions
                 {
                     options.AppId = facebookAppId;
                     options.AppSecret = facebookAppSecret;
+                    options.Events.OnRemoteFailure = HandleRemoteFailure;
                 });
             }
 
             return services;
+        }
+
+        // Bez ovaa hooka, OAuth handler-ot frla exception koga userot kje klikne
+        // "Cancel" na consent stranata na provajderot (Facebook posebno) - ke se
+        // pokaze 500 namesto friendly poraka. Ovde gi presretvame i go redirektirame
+        // browser-ot nazad do originalniot RedirectUri (sign-in callback ili link callback)
+        // so remoteError query param - controllerite vekje znaat kako da go handlat.
+        private static Task HandleRemoteFailure(RemoteFailureContext context)
+        {
+            var redirectUrl = context.Properties?.RedirectUri ?? "/Account/Login";
+            var separator = redirectUrl.Contains('?') ? "&" : "?";
+            var error = Uri.EscapeDataString(
+                context.Failure?.Message ?? "External sign-in was cancelled or failed.");
+
+            context.Response.Redirect($"{redirectUrl}{separator}remoteError={error}");
+            context.HandleResponse();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/AspNetCoreMvcTemplate.Web/Program.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Program.cs
@@ -34,6 +34,7 @@ namespace AspNetCoreMvcTemplate.Web
             builder.Services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+            // So ova se dodava authentication services, user manager, sign-in manager, role manager, identity cookies...
             builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
             {
                 options.Password.RequiredLength = 6;
@@ -56,6 +57,7 @@ namespace AspNetCoreMvcTemplate.Web
 
             builder.Services.AddAuthorizationPolicies();
 
+            //var authBuilder = services.AddAuthentication() ova samo extends the existing authentication setup, ne go pregazuva.
             builder.Services.AddExternalAuthentication(builder.Configuration);
 
             builder.Services.ConfigureApplicationCookie(options =>

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangeEmailViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangeEmailViewModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Profile
+{
+    public class ChangeEmailViewModel
+    {
+        [Display(Name = "Current email")]
+        public string CurrentEmail { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        [StringLength(256)]
+        [Display(Name = "New email")]
+        public string NewEmail { get; set; } = string.Empty;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangeNameViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangeNameViewModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Profile
+{
+    public class ChangeNameViewModel
+    {
+        [Required]
+        [StringLength(100)]
+        [Display(Name = "Name")]
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangePasswordViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ChangePasswordViewModel.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Profile
+{
+    public class ChangePasswordViewModel
+    {
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Current password")]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [Display(Name = "New password")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Compare(nameof(NewPassword), ErrorMessage = "The new password and confirmation password do not match.")]
+        [Display(Name = "Confirm new password")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ProfileIndexViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/ProfileIndexViewModel.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Profile
+{
+    public class ProfileIndexViewModel
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        public bool EmailConfirmed { get; set; }
+
+        public bool HasPassword { get; set; }
+
+        // Provajderi koi se vekje povrzani so user-ot.
+        public IList<UserLoginInfo> CurrentLogins { get; set; } = new List<UserLoginInfo>();
+
+        // Provajderi koi se konfigurirani vo aplikacijata no ushte ne se povrzani.
+        public IList<AuthenticationScheme> AvailableProviders { get; set; } = new List<AuthenticationScheme>();
+
+        // Statusna poraka po redirect (TempData)
+        public string? StatusMessage { get; set; }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/SetPasswordViewModel.cs
+++ b/src/AspNetCoreMvcTemplate.Web/ViewModels/Profile/SetPasswordViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetCoreMvcTemplate.Web.ViewModels.Profile
+{
+    // Koristi se za useri koi nemaat lokalna lozinka (registriraha preku eksteren provajder).
+    public class SetPasswordViewModel
+    {
+        [Required]
+        [DataType(DataType.Password)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [Display(Name = "New password")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Compare(nameof(NewPassword), ErrorMessage = "The new password and confirmation password do not match.")]
+        [Display(Name = "Confirm new password")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangeEmail.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangeEmail.cshtml
@@ -1,0 +1,35 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Profile
+@model ChangeEmailViewModel
+
+@{
+    ViewData["Title"] = "Change email";
+}
+
+<h1>Change your email</h1>
+
+<p class="text-muted">
+    We'll send a confirmation link to the new email address. The change takes effect only after
+    you click that link, so your current email keeps working until then.
+</p>
+
+<form asp-action="ChangeEmail" method="post">
+    <div asp-validation-summary="All" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="CurrentEmail" class="form-label"></label>
+        <input asp-for="CurrentEmail" class="form-control" readonly />
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="NewEmail" class="form-label"></label>
+        <input asp-for="NewEmail" class="form-control" />
+        <span asp-validation-for="NewEmail" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Send confirmation</button>
+    <a asp-action="Index" class="btn btn-link">Cancel</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangeName.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangeName.cshtml
@@ -1,0 +1,25 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Profile
+@model ChangeNameViewModel
+
+@{
+    ViewData["Title"] = "Change name";
+}
+
+<h1>Change your name</h1>
+
+<form asp-action="ChangeName" method="post">
+    <div asp-validation-summary="All" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="Name" class="form-label"></label>
+        <input asp-for="Name" class="form-control" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-action="Index" class="btn btn-link">Cancel</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangePassword.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Profile/ChangePassword.cshtml
@@ -1,0 +1,37 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Profile
+@model ChangePasswordViewModel
+
+@{
+    ViewData["Title"] = "Change password";
+}
+
+<h1>Change your password</h1>
+
+<form asp-action="ChangePassword" method="post">
+    <div asp-validation-summary="All" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="CurrentPassword" class="form-label"></label>
+        <input asp-for="CurrentPassword" class="form-control" />
+        <span asp-validation-for="CurrentPassword" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="NewPassword" class="form-label"></label>
+        <input asp-for="NewPassword" class="form-control" />
+        <span asp-validation-for="NewPassword" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="ConfirmPassword" class="form-label"></label>
+        <input asp-for="ConfirmPassword" class="form-control" />
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-action="Index" class="btn btn-link">Cancel</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Profile/Index.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Profile/Index.cshtml
@@ -1,0 +1,114 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Profile
+@model ProfileIndexViewModel
+
+@{
+    ViewData["Title"] = "Profile";
+}
+
+<h1>Your profile</h1>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="alert alert-info" role="alert">@Model.StatusMessage</div>
+}
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">Account</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Name</dt>
+                    <dd class="col-sm-8">@Model.Name</dd>
+
+                    <dt class="col-sm-4">Email</dt>
+                    <dd class="col-sm-8">
+                        @Model.Email
+                        @if (Model.EmailConfirmed)
+                        {
+                            <span class="badge bg-success ms-1">Confirmed</span>
+                        }
+                        else
+                        {
+                            <span class="badge bg-warning text-dark ms-1">Unconfirmed</span>
+                        }
+                    </dd>
+
+                    <dt class="col-sm-4">Password</dt>
+                    <dd class="col-sm-8">
+                        @if (Model.HasPassword)
+                        {
+                            <span class="badge bg-success">Set</span>
+                        }
+                        else
+                        {
+                            <span class="badge bg-secondary">Not set</span>
+                        }
+                    </dd>
+                </dl>
+            </div>
+            <div class="card-footer bg-white">
+                <a asp-action="ChangeName" class="btn btn-outline-primary btn-sm">Change name</a>
+                <a asp-action="ChangeEmail" class="btn btn-outline-primary btn-sm">Change email</a>
+                @if (Model.HasPassword)
+                {
+                    <a asp-action="ChangePassword" class="btn btn-outline-primary btn-sm">Change password</a>
+                }
+                else
+                {
+                    <a asp-action="SetPassword" class="btn btn-outline-primary btn-sm">Set password</a>
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">Linked accounts</div>
+            <div class="card-body">
+                @if (Model.CurrentLogins.Count == 0)
+                {
+                    <p class="text-muted mb-0">You don't have any external accounts linked.</p>
+                }
+                else
+                {
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            @foreach (var login in Model.CurrentLogins)
+                            {
+                                <tr>
+                                    <td>@(login.ProviderDisplayName ?? login.LoginProvider)</td>
+                                    <td class="text-end">
+                                        <form asp-action="RemoveLogin" method="post" class="d-inline">
+                                            <input type="hidden" name="loginProvider" value="@login.LoginProvider" />
+                                            <input type="hidden" name="providerKey" value="@login.ProviderKey" />
+                                            <button type="submit" class="btn btn-outline-danger btn-sm">Unlink</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+            @if (Model.AvailableProviders.Count > 0)
+            {
+                <div class="card-footer bg-white">
+                    <span class="me-2">Link another:</span>
+                    <form asp-action="LinkLogin" method="post" class="d-inline">
+                        @foreach (var provider in Model.AvailableProviders)
+                        {
+                            <button type="submit"
+                                    class="btn btn-outline-secondary btn-sm me-1"
+                                    name="provider"
+                                    value="@provider.Name"
+                                    title="Link your @provider.DisplayName account">
+                                @provider.DisplayName
+                            </button>
+                        }
+                    </form>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/src/AspNetCoreMvcTemplate.Web/Views/Profile/SetPassword.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Profile/SetPassword.cshtml
@@ -1,0 +1,36 @@
+@using AspNetCoreMvcTemplate.Web.ViewModels.Profile
+@model SetPasswordViewModel
+
+@{
+    ViewData["Title"] = "Set password";
+}
+
+<h1>Set a local password</h1>
+
+<p class="text-muted">
+    You don't have a local password yet. Set one to enable signing in with email and password
+    in addition to your external providers.
+</p>
+
+<form asp-action="SetPassword" method="post">
+    <div asp-validation-summary="All" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="NewPassword" class="form-label"></label>
+        <input asp-for="NewPassword" class="form-control" />
+        <span asp-validation-for="NewPassword" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="ConfirmPassword" class="form-label"></label>
+        <input asp-for="ConfirmPassword" class="form-control" />
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Set password</button>
+    <a asp-action="Index" class="btn btn-link">Cancel</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/AspNetCoreMvcTemplate.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Shared/_LoginPartial.cshtml
@@ -22,7 +22,9 @@
         </li>
     }
     <li class="nav-item d-flex align-items-center me-2">
-        <span class="nav-link text-dark">Hello  @(currentUser?.Name ?? User.Identity?.Name)</span>
+        <a class="nav-link text-dark" asp-controller="Profile" asp-action="Index">
+            Hello @(currentUser?.Name ?? User.Identity?.Name)
+        </a>
     </li>
     <li class="nav-item d-flex align-items-center me-2">
         <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/ProfileControllerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/ProfileControllerTests.cs
@@ -1,0 +1,351 @@
+using System.Security.Claims;
+using AspNetCoreMvcTemplate.Emailing.Abstractions;
+using AspNetCoreMvcTemplate.Emailing.Models;
+using AspNetCoreMvcTemplate.Web.Controllers;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using AspNetCoreMvcTemplate.Web.ViewModels.Profile;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Controllers;
+
+public class ProfileControllerTests
+{
+    [Fact]
+    public async Task ChangePassword_Post_ReturnsView_WhenCurrentPasswordIsWrong()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager
+            .Setup(x => x.ChangePasswordAsync(user, "wrong", "Newpass1"))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Incorrect password." }));
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ChangePassword(new ChangePasswordViewModel
+        {
+            CurrentPassword = "wrong",
+            NewPassword = "Newpass1",
+            ConfirmPassword = "Newpass1"
+        });
+
+        Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+    }
+
+    [Fact]
+    public async Task ChangePassword_Post_RedirectsToIndex_WhenSuccessful()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager
+            .Setup(x => x.ChangePasswordAsync(user, "Old1", "New1"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        signInManager
+            .Setup(x => x.RefreshSignInAsync(user))
+            .Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ChangePassword(new ChangePasswordViewModel
+        {
+            CurrentPassword = "Old1",
+            NewPassword = "New1",
+            ConfirmPassword = "New1"
+        });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(ProfileController.Index), redirect.ActionName);
+        signInManager.Verify(x => x.RefreshSignInAsync(user), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetPassword_Get_RedirectsToChangePassword_WhenUserAlreadyHasPassword()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager.Setup(x => x.HasPasswordAsync(user)).ReturnsAsync(true);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.SetPassword();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(ProfileController.ChangePassword), redirect.ActionName);
+    }
+
+    [Fact]
+    public async Task SetPassword_Post_AddsPassword_WhenUserHasNoPassword()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager.Setup(x => x.HasPasswordAsync(user)).ReturnsAsync(false);
+        userManager
+            .Setup(x => x.AddPasswordAsync(user, "Newpass1"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        signInManager.Setup(x => x.RefreshSignInAsync(user)).Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.SetPassword(new SetPasswordViewModel
+        {
+            NewPassword = "Newpass1",
+            ConfirmPassword = "Newpass1"
+        });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(ProfileController.Index), redirect.ActionName);
+        userManager.Verify(x => x.AddPasswordAsync(user, "Newpass1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangeEmail_Post_SendsConfirmationToNewAddress()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager
+            .Setup(x => x.GenerateChangeEmailTokenAsync(user, "new@test.com"))
+            .ReturnsAsync("test-token");
+
+        EmailMessage? captured = null;
+        emailSender
+            .Setup(x => x.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(new EmailSendResult { Succeeded = true });
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ChangeEmail(new ChangeEmailViewModel
+        {
+            NewEmail = "new@test.com"
+        });
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.NotNull(captured);
+        Assert.Equal("new@test.com", captured!.To);
+    }
+
+    [Fact]
+    public async Task ChangeEmail_Post_AddsModelError_WhenNewEmailEqualsCurrent()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ChangeEmail(new ChangeEmailViewModel
+        {
+            NewEmail = user.Email!
+        });
+
+        Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+        emailSender.Verify(x => x.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConfirmEmailChange_Get_UpdatesEmailAndUserName_WhenTokenIsValid()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        userManager
+            .Setup(x => x.ChangeEmailAsync(user, "new@test.com", "valid-token"))
+            .ReturnsAsync(IdentityResult.Success);
+        userManager
+            .Setup(x => x.SetUserNameAsync(user, "new@test.com"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        signInManager.Setup(x => x.RefreshSignInAsync(user)).Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ConfirmEmailChange(user.Id, "new@test.com", "valid-token");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(ProfileController.Index), redirect.ActionName);
+        userManager.Verify(x => x.SetUserNameAsync(user, "new@test.com"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveLogin_Refuses_WhenWouldOrphanAccount()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager.Setup(x => x.HasPasswordAsync(user)).ReturnsAsync(false);
+        userManager
+            .Setup(x => x.GetLoginsAsync(user))
+            .ReturnsAsync(new List<UserLoginInfo>
+            {
+                new("Google", "key-1", "Google")
+            });
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.RemoveLogin("Google", "key-1");
+
+        Assert.IsType<RedirectToActionResult>(result);
+        userManager.Verify(
+            x => x.RemoveLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RemoveLogin_Succeeds_WhenUserHasPassword()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager.Setup(x => x.HasPasswordAsync(user)).ReturnsAsync(true);
+        userManager
+            .Setup(x => x.GetLoginsAsync(user))
+            .ReturnsAsync(new List<UserLoginInfo>
+            {
+                new("Google", "key-1", "Google")
+            });
+        userManager
+            .Setup(x => x.RemoveLoginAsync(user, "Google", "key-1"))
+            .ReturnsAsync(IdentityResult.Success);
+        signInManager.Setup(x => x.RefreshSignInAsync(user)).Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.RemoveLogin("Google", "key-1");
+
+        Assert.IsType<RedirectToActionResult>(result);
+        userManager.Verify(x => x.RemoveLoginAsync(user, "Google", "key-1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangeName_Post_UpdatesUserAndRefreshesSignIn()
+    {
+        var userManager = CreateUserManagerMock();
+        var signInManager = CreateSignInManagerMock(userManager.Object);
+        var emailSender = new Mock<IEmailSender>();
+
+        var user = CreateUser();
+        userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        signInManager.Setup(x => x.RefreshSignInAsync(user)).Returns(Task.CompletedTask);
+
+        var controller = CreateController(userManager.Object, signInManager.Object, emailSender.Object);
+
+        var result = await controller.ChangeName(new ChangeNameViewModel { Name = "New Name" });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(ProfileController.Index), redirect.ActionName);
+        Assert.Equal("New Name", user.Name);
+        signInManager.Verify(x => x.RefreshSignInAsync(user), Times.Once);
+    }
+
+    private static ApplicationUser CreateUser()
+    {
+        return new ApplicationUser
+        {
+            Id = "user-1",
+            UserName = "user@test.com",
+            Email = "user@test.com",
+            Name = "Test User"
+        };
+    }
+
+    private static ProfileController CreateController(
+        UserManager<ApplicationUser> userManager,
+        SignInManager<ApplicationUser> signInManager,
+        IEmailSender emailSender)
+    {
+        var controller = new ProfileController(
+            userManager,
+            signInManager,
+            emailSender,
+            NullLogger<ProfileController>.Instance);
+
+        controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        // Url helper za Url.Action vo ChangeEmail.
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns("/Profile/ConfirmEmailChange");
+        controller.Url = urlHelper.Object;
+
+        // TempData treba da postoi za TempData["..."] da raboti.
+        controller.TempData = new Microsoft.AspNetCore.Mvc.ViewFeatures.TempDataDictionary(
+            controller.HttpContext,
+            new Mock<Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataProvider>().Object);
+
+        return controller;
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<SignInManager<ApplicationUser>> CreateSignInManagerMock(UserManager<ApplicationUser> userManager)
+    {
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();
+
+        return new Mock<SignInManager<ApplicationUser>>(
+            userManager,
+            contextAccessor.Object,
+            claimsFactory.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+}


### PR DESCRIPTION
Summary

Adds self-service profile management for authenticated users.

This branch introduces a dedicated profile area that allows users to manage their own account information while preserving a strict separation between self-service profile management and future admin user-management features.

It completes the core authenticated user lifecycle after registration, login, security, and external authentication by adding safe account ownership flows.

What’s included
Profile management
Added ProfileController
Added profile overview page
Added self-service profile navigation entry
Self-service account updates
Added change name flow
Added change password flow
Added set password flow for external-login-only users
Added change email flow with confirmation token
External login management
Added linked external login display
Added external provider linking flow
Added external provider unlink flow
Added orphan-prevention guard to ensure users retain at least one sign-in method
Supporting UI / models
Added profile view models
Added profile views for account management flows
Added status messaging for profile operations
Implementation notes
All profile actions operate only on the currently authenticated user
No arbitrary user editing routes were introduced
Identity APIs are used for Identity-owned operations
Authentication cookie is refreshed after profile mutations where needed
Email changes require confirmation before being applied
Password flows correctly distinguish between changing an existing password and setting a new local password
Architectural intent

This branch establishes the self-service account-management boundary:

Profile = authenticated user manages their own account
Admin user management = privileged management of other users (future branch)

That separation keeps ownership and authorization concerns clean and avoids mixing normal user profile management with administrative user operations.