### PR TITLE
Add configuration-driven feature toggles for optional application capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Error handling**: `ErrorController` with ServerError (500) and StatusCodeError (404/403)
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check
-- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`, `AddExternalAuthentication()`
+- **Feature toggles**: `Features/` folder defines `FeatureOptions` (5 bool flags: `AdminArea`, `ProfileManagement`, `Registration`, `ExternalLogins`, `EmailConfirmation`), `IFeatureManager` (`IsEnabled(string)`), `FeatureManager` (reads `IOptions<FeatureOptions>` via reflection), and `FeatureGateAttribute` (action filter, returns 404 when feature off — "this feature doesn't exist in this app" semantics, NOT 403). Wired via `AddFeatureManagement()` in Program.cs. Startup-time decisions (Identity's `RequireConfirmedEmail`, conditional `AddExternalAuthentication` call) bind a local `FeatureOptions` directly from config; runtime decisions (controllers, views) consume `IFeatureManager` via DI. Views (`_LoginPartial`) use `@inject IFeatureManager` to hide nav links for disabled features. Default for all flags is `true` so apps with no `Features` section behave exactly like before.
+- **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`, `AddExternalAuthentication()`, `AddFeatureManagement()`
 
 ## Completed Features
 
@@ -46,7 +47,8 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - GitHub Actions CI (build + test)
 - GitHub Actions CD (IIS deployment to staging)
 - Data protection keys persisted to file system
-- 66+ unit and integration tests
+- Feature toggles for AdminArea, ProfileManagement, Registration, ExternalLogins, EmailConfirmation (configurable via `Features` section in appsettings.json)
+- 73+ unit and integration tests
 
 ## Branching
 

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/DashboardController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/DashboardController.cs
@@ -1,4 +1,5 @@
 using AspNetCoreMvcTemplate.Web.Authorization;
+using AspNetCoreMvcTemplate.Web.Features;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -6,6 +7,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+    [FeatureGate(nameof(FeatureOptions.AdminArea))]
     public class DashboardController : Controller
     {
         public IActionResult Index()

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/RolesController.cs
@@ -1,5 +1,6 @@
 using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
 using AspNetCoreMvcTemplate.Web.Authorization;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.Options;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +13,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
     [Area("Admin")]
     [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
     [AutoValidateAntiforgeryToken]
+    [FeatureGate(nameof(FeatureOptions.AdminArea))]
     public class RolesController : Controller
     {
         private readonly RoleManager<IdentityRole> roleManager;

--- a/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Areas/Admin/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using AspNetCoreMvcTemplate.Web.Areas.Admin.ViewModels;
 using AspNetCoreMvcTemplate.Web.Authorization;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.Options;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +13,7 @@ namespace AspNetCoreMvcTemplate.Web.Areas.Admin.Controllers
     [Area("Admin")]
     [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
     [AutoValidateAntiforgeryToken]
+    [FeatureGate(nameof(FeatureOptions.AdminArea))]
     public class UsersController : Controller
     {
         private readonly UserManager<ApplicationUser> userManager;

--- a/src/AspNetCoreMvcTemplate.Web/Controllers/AccountController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Controllers/AccountController.cs
@@ -1,5 +1,6 @@
 using AspNetCoreMvcTemplate.Emailing.Abstractions;
 using AspNetCoreMvcTemplate.Emailing.Models;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.ViewModels.Account;
 using Microsoft.AspNetCore.Authorization;
@@ -15,17 +16,20 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
         private readonly UserManager<ApplicationUser> userManager;
         private readonly SignInManager<ApplicationUser> signInManager;
         private readonly IEmailSender emailSender;
+        private readonly IFeatureManager featureManager;
         private readonly ILogger<AccountController> logger;
 
         public AccountController(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IEmailSender emailSender,
+            IFeatureManager featureManager,
             ILogger<AccountController> logger)
         {
             this.userManager = userManager;
             this.signInManager = signInManager;
             this.emailSender = emailSender;
+            this.featureManager = featureManager;
             this.logger = logger;
         }
 
@@ -97,6 +101,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
 
         [HttpGet]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.Registration))]
         public IActionResult Register()
         {
             return View();
@@ -104,6 +109,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
 
         [HttpPost]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.Registration))]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
             if (!ModelState.IsValid)
@@ -111,19 +117,31 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
                 return View(model);
             }
 
+            var emailConfirmationEnabled = featureManager.IsEnabled(nameof(FeatureOptions.EmailConfirmation));
+
             var user = new ApplicationUser
             {
                 UserName = model.Email,
                 Email = model.Email,
-                Name = model.Name
+                Name = model.Name,
+                // Ako EmailConfirmation feature-ot e isklucen, novite useri vlegvaat
+                // direktno bez email confirmation step.
+                EmailConfirmed = !emailConfirmationEnabled
             };
 
             var result = await userManager.CreateAsync(user, model.Password);
 
             if (result.Succeeded)
             {
-                //Create token for email confirmation and send email with the token
+                if (!emailConfirmationEnabled)
+                {
+                    // Sleep mode na confirmation flow-ot - signiraj se direktno.
+                    await signInManager.SignInAsync(user, isPersistent: false);
+                    logger.LogInformation("User {Email} registered and signed in (email confirmation disabled).", model.Email);
+                    return RedirectToAction("Index", "Home");
+                }
 
+                //Create token for email confirmation and send email with the token
                 var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
 
                 var confirmationLink = Url.Action(nameof(ConfirmEmail), "Account", new { userId = user.Id, token }, Request.Scheme);
@@ -174,6 +192,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
 
         [HttpGet]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.Registration))]
         public IActionResult RegisterConfirmation(string? email)
         {
             ViewBag.Email = email;
@@ -224,6 +243,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
         // redirektira nazad do ExternalLoginCallback.
         [HttpPost]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.ExternalLogins))]
         public IActionResult ExternalLogin(string provider, string? returnUrl = null)
         {
             if (string.IsNullOrWhiteSpace(provider))
@@ -244,6 +264,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
         //  3. Nov user bez email claim -> redirektiraj na formata za potvrda
         [HttpGet]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.ExternalLogins))]
         public async Task<IActionResult> ExternalLoginCallback(string? returnUrl = null, string? remoteError = null)
         {
             if (remoteError != null)
@@ -308,6 +329,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
         // Fallback za Sluchaj 3 - userot rachno vnese email.
         [HttpPost]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.ExternalLogins))]
         public async Task<IActionResult> ExternalLoginConfirmation(ExternalLoginConfirmationViewModel model)
         {
             if (!ModelState.IsValid)
@@ -544,6 +566,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
 
         [HttpGet]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.EmailConfirmation))]
         public IActionResult ResendConfirmationEmail(string? email = null)
         {
             var model = new EmailInputViewModel
@@ -556,6 +579,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
 
         [HttpPost]
         [AllowAnonymous]
+        [FeatureGate(nameof(FeatureOptions.EmailConfirmation))]
         //Napraven e ovoj endpoint so namera da se koristi i za resend confirmation email. Ne se koristi za forgot password zatoa sto za forgot password ne e potrebno da se proveruva dali email e confirmed, a i tokenot e razlicen.
         public async Task<IActionResult> ResendConfirmationEmail(EmailInputViewModel model)
         {

--- a/src/AspNetCoreMvcTemplate.Web/Controllers/ProfileController.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Controllers/ProfileController.cs
@@ -1,5 +1,6 @@
 using AspNetCoreMvcTemplate.Emailing.Abstractions;
 using AspNetCoreMvcTemplate.Emailing.Models;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.ViewModels.Profile;
 using Microsoft.AspNetCore.Authentication;
@@ -12,6 +13,7 @@ namespace AspNetCoreMvcTemplate.Web.Controllers
     // Self-service profile actions. Site dejstva baraat avtenticiran user.
     [Authorize]
     [AutoValidateAntiforgeryToken]
+    [FeatureGate(nameof(FeatureOptions.ProfileManagement))]
     public class ProfileController : Controller
     {
         private readonly UserManager<ApplicationUser> userManager;

--- a/src/AspNetCoreMvcTemplate.Web/Extensions/FeatureServiceCollectionExtensions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Extensions/FeatureServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using AspNetCoreMvcTemplate.Web.Features;
+
+namespace AspNetCoreMvcTemplate.Web.Extensions
+{
+    public static class FeatureServiceCollectionExtensions
+    {
+        // Binds "Features" sekcijata na FeatureOptions i registrira FeatureManager
+        // kako Singleton. FeatureOptions ne se menja vo runtime (samo na startup),
+        // taka shto Singleton e bezbedno i efikasno.
+        public static IServiceCollection AddFeatureManagement(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.Configure<FeatureOptions>(configuration.GetSection("Features"));
+            services.AddSingleton<IFeatureManager, FeatureManager>();
+            return services;
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Features/FeatureGateAttribute.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/FeatureGateAttribute.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace AspNetCoreMvcTemplate.Web.Features
+{
+    // Action filter koj vrakja 404 ako feature-ot e isklucen, ili dozvoluva
+    // request-ot da prodolzhi normalno ako e vklucen.
+    //
+    // Zoshto 404 a ne 403? Iz perspektivata na korisnikot, isklucena feature
+    // ne postoi vo aplikacijata - 404 (Not Found) e iskreniot odgovor.
+    // 403 (Forbidden) bi sugeriralo "postoi ama nemash dozvola" - shto leak-uva
+    // informacija za feature-ite shto gi imame.
+    //
+    // Koristenje:
+    //   [FeatureGate(nameof(FeatureOptions.AdminArea))]
+    //   public class DashboardController : Controller { ... }
+    //
+    // IAuthorizationFilter se izvrshuva NAJRANO vo pipeline-ot - pred model
+    // binding, pred action filters. Tochno kade sakame - ne sakame da rasipuvame
+    // resursi binduvajki model za action koja po toa ke se otkaze.
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+    public class FeatureGateAttribute : Attribute, IAuthorizationFilter
+    {
+        private readonly string featureName;
+
+        public FeatureGateAttribute(string featureName)
+        {
+            this.featureName = featureName;
+        }
+
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            // Resolvirame IFeatureManager od request-scoped DI kontejnerot.
+            // Atributite ne mozat da imaat constructor injection - ova e standarden
+            // workaround vo MVC.
+            var featureManager = context.HttpContext.RequestServices
+                .GetService(typeof(IFeatureManager)) as IFeatureManager;
+
+            if (featureManager is null || !featureManager.IsEnabled(featureName))
+            {
+                context.Result = new NotFoundResult();
+            }
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Features/FeatureGateAttribute.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/FeatureGateAttribute.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetCoreMvcTemplate.Web.Features
 {
@@ -33,10 +34,16 @@ namespace AspNetCoreMvcTemplate.Web.Features
             // Resolvirame IFeatureManager od request-scoped DI kontejnerot.
             // Atributite ne mozat da imaat constructor injection - ova e standarden
             // workaround vo MVC.
+            //
+            // GetRequiredService (a ne GetService) namerno: ako IFeatureManager ne
+            // e registriran, toa e application wiring greshka - pobezbedno e da
+            // frlame exception otkolku da pretvorame site feature-gated routi vo
+            // 404. tivok 404 izgleda kako "feature isklucena" i e loso za
+            // debug. Fail-fast e podobro.
             var featureManager = context.HttpContext.RequestServices
-                .GetService(typeof(IFeatureManager)) as IFeatureManager;
+                .GetRequiredService<IFeatureManager>();
 
-            if (featureManager is null || !featureManager.IsEnabled(featureName))
+            if (!featureManager.IsEnabled(featureName))
             {
                 context.Result = new NotFoundResult();
             }

--- a/src/AspNetCoreMvcTemplate.Web/Features/FeatureManager.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/FeatureManager.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Features
+{
+    // Trivijalna implementacija - chita FeatureOptions preku IOptions i vraka
+    // bool vrednosta na imenuvaniot property preku reflection. Reflection-ot
+    // e brz (~mikrosekundi) i propertite se vsushnost samo 5 - ne e bottleneck.
+    //
+    // Ako se prefrlime na po-slozhena strategija (na primer, feature flags vo
+    // baza, percentage rollout, A/B testing), ja menjame samo ovaa klasa - site
+    // konzumeri (controllers, views, filters) baraat IFeatureManager interfejsot
+    // i ne se zasegnati od promena.
+    public class FeatureManager : IFeatureManager
+    {
+        private readonly FeatureOptions options;
+
+        public FeatureManager(IOptions<FeatureOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+
+        // moze i vaka Dictionary<string, Func<FeatureOptions, bool>> ama nemora sega, i ova e dovoljno
+        public bool IsEnabled(string featureName)
+        {
+            if (string.IsNullOrWhiteSpace(featureName))
+            {
+                return false;
+            }
+
+            var property = typeof(FeatureOptions).GetProperty(featureName);
+            if (property is null || property.PropertyType != typeof(bool))
+            {
+                return false;
+            }
+
+            return (bool)(property.GetValue(options) ?? false);
+        }
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Features/FeatureManager.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/FeatureManager.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.Options;
 
 namespace AspNetCoreMvcTemplate.Web.Features
@@ -20,7 +21,7 @@ namespace AspNetCoreMvcTemplate.Web.Features
         }
 
 
-        // moze i vaka Dictionary<string, Func<FeatureOptions, bool>> ama nemora sega, i ova e dovoljno
+        // moze i vaka Dictionary<string, Func<FeatureOptions, bool>> ama i nemora 
         public bool IsEnabled(string featureName)
         {
             if (string.IsNullOrWhiteSpace(featureName))
@@ -28,7 +29,12 @@ namespace AspNetCoreMvcTemplate.Web.Features
                 return false;
             }
 
-            var property = typeof(FeatureOptions).GetProperty(featureName);
+            // IgnoreCase za da ne e fragile na typo-i vo casing.
+            // case-insensitive e pobezbedna default vrednost.
+            var property = typeof(FeatureOptions).GetProperty(
+                featureName,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
             if (property is null || property.PropertyType != typeof(bool))
             {
                 return false;

--- a/src/AspNetCoreMvcTemplate.Web/Features/FeatureOptions.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/FeatureOptions.cs
@@ -1,0 +1,26 @@
+namespace AspNetCoreMvcTemplate.Web.Features
+{
+    // Strongly-typed mapping na "Features" sekcijata vo appsettings.json.
+    // Default vrednosti se site `true` - ako nekoj klonira template-ot i ne
+    // dodade Features sekcija, app-ot raboti kako i predtoa (sve vkluceno).
+    public class FeatureOptions
+    {
+        // Admin Area (Dashboard, Roles CRUD, Users management).
+        public bool AdminArea { get; set; } = true;
+
+        // Self-service profile (change name/password/email, manage linked logins).
+        public bool ProfileManagement { get; set; } = true;
+
+        // Public user registration (Register stranata + RegisterConfirmation).
+        // Off = samo admin moze da kreira useri preku Admin area.
+        public bool Registration { get; set; } = true;
+
+        // Hard switch za eksterni provajderi. Off = AddExternalAuthentication
+        // se preskoknuva celosno bez ogled na ClientId konfiguracijata.
+        public bool ExternalLogins { get; set; } = true;
+
+        // Off = users get EmailConfirmed = true on register, no confirmation email,
+        // RequireConfirmedEmail = false (signing in works without email confirmation).
+        public bool EmailConfirmation { get; set; } = true;
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Features/IFeatureManager.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Features/IFeatureManager.cs
@@ -1,0 +1,10 @@
+namespace AspNetCoreMvcTemplate.Web.Features
+{
+    // Apstrakcija za proveruvanje na feature toggles.
+    // Koristi se vo controllers, views, action filters - sekade kade ni treba
+    // run-time odluka "dali ovaa feature e vklucena?".
+    public interface IFeatureManager
+    {
+        bool IsEnabled(string featureName);
+    }
+}

--- a/src/AspNetCoreMvcTemplate.Web/Program.cs
+++ b/src/AspNetCoreMvcTemplate.Web/Program.cs
@@ -2,6 +2,7 @@ using AspNetCoreMvcTemplate.Emailing.DependencyInjection;
 using AspNetCoreMvcTemplate.Web.Authorization;
 using AspNetCoreMvcTemplate.Web.Data;
 using AspNetCoreMvcTemplate.Web.Extensions;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
@@ -21,8 +22,14 @@ namespace AspNetCoreMvcTemplate.Web
             builder.Services.AddControllersWithViews();
             builder.Services.AddEmailing(builder.Configuration);
             builder.Services.AddAdminBootstrap(builder.Configuration);
+            builder.Services.AddFeatureManagement(builder.Configuration);
             builder.Services.AddHealthChecks()
                 .AddDbContextCheck<ApplicationDbContext>();
+
+            // Chitame Features sekcijata sinhrono za startup-time odluki (Identity options,
+            // dali da registrirame eksterni provajderi). Runtime proverki idat preku IFeatureManager.
+            var features = new FeatureOptions();
+            builder.Configuration.GetSection("Features").Bind(features);
 
             var keysPath = builder.Configuration["DataProtection:KeysPath"]
             ?? throw new InvalidOperationException("DataProtection:KeysPath is not configured.");
@@ -43,7 +50,9 @@ namespace AspNetCoreMvcTemplate.Web
                 options.Password.RequireLowercase = false;
                 options.Password.RequireNonAlphanumeric = false;
 
-                options.SignIn.RequireConfirmedEmail = true;
+                // Ako EmailConfirmation feature-ot e isklucen, dozvoluvame
+                // sign-in bez potvrden email (i Register flow ne prakja confirmation email).
+                options.SignIn.RequireConfirmedEmail = features.EmailConfirmation;
 
                 options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
                 options.Lockout.MaxFailedAccessAttempts = 5;
@@ -58,7 +67,12 @@ namespace AspNetCoreMvcTemplate.Web
             builder.Services.AddAuthorizationPolicies();
 
             //var authBuilder = services.AddAuthentication() ova samo extends the existing authentication setup, ne go pregazuva.
-            builder.Services.AddExternalAuthentication(builder.Configuration);
+            // Hard switch: koga ExternalLogins e isklucen, voopsto ne registriratame
+            // provajderi - dury i ako se konfigurirani ClientId/AppId vo settings.
+            if (features.ExternalLogins)
+            {
+                builder.Services.AddExternalAuthentication(builder.Configuration);
+            }
 
             builder.Services.ConfigureApplicationCookie(options =>
             {

--- a/src/AspNetCoreMvcTemplate.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/AspNetCoreMvcTemplate.Web/Views/Shared/_LoginPartial.cshtml
@@ -1,6 +1,8 @@
-﻿@using AspNetCoreMvcTemplate.Web.Models.Identity
+@using AspNetCoreMvcTemplate.Web.Features
+@using AspNetCoreMvcTemplate.Web.Models.Identity
 @using Microsoft.AspNetCore.Identity
 @inject UserManager<ApplicationUser> UserManager
+@inject IFeatureManager Features
 
 @{
     ApplicationUser? currentUser = null;
@@ -15,16 +17,25 @@
 
 @if (User.Identity?.IsAuthenticated == true)
 {
-    @if (User.IsInRole("Admin"))
+    @* Admin link se prikazuva samo ako AdminArea feature-ot e vklucen *@
+    @if (User.IsInRole("Admin") && Features.IsEnabled(nameof(FeatureOptions.AdminArea)))
     {
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="Admin" asp-controller="Dashboard" asp-action="Index">Admin</a>
         </li>
     }
+    @* Profile link e link samo ako ProfileManagement e vklucen, inaku e plain text *@
     <li class="nav-item d-flex align-items-center me-2">
-        <a class="nav-link text-dark" asp-controller="Profile" asp-action="Index">
-            Hello @(currentUser?.Name ?? User.Identity?.Name)
-        </a>
+        @if (Features.IsEnabled(nameof(FeatureOptions.ProfileManagement)))
+        {
+            <a class="nav-link text-dark" asp-controller="Profile" asp-action="Index">
+                Hello @(currentUser?.Name ?? User.Identity?.Name)
+            </a>
+        }
+        else
+        {
+            <span class="nav-link text-dark">Hello @(currentUser?.Name ?? User.Identity?.Name)</span>
+        }
     </li>
     <li class="nav-item d-flex align-items-center me-2">
         <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
@@ -34,10 +45,14 @@
 }
 else
 {
+    @* Register link se prikazuva samo ako public registration e vklucena *@
+    @if (Features.IsEnabled(nameof(FeatureOptions.Registration)))
+    {
+        <li class="nav-item">
+            <a class="nav-link text-dark" asp-controller="Account" asp-action="Register">Register</a>
+        </li>
+    }
     <li class="nav-item">
-        <a class="nav-link text-dark" asp-controller="Account" asp-action="Register">Register</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link text-dark" asp-controller="Account" asp-action="Login">Login</a> 
+        <a class="nav-link text-dark" asp-controller="Account" asp-action="Login">Login</a>
     </li>
 }

--- a/src/AspNetCoreMvcTemplate.Web/appsettings.json
+++ b/src/AspNetCoreMvcTemplate.Web/appsettings.json
@@ -41,6 +41,13 @@
   "DataProtection": {
     "KeysPath": "D:\\Sites\\AspNetCoreMvcTemplate\\keys"
   },
+  "Features": {
+    "AdminArea": true,
+    "ProfileManagement": true,
+    "Registration": true,
+    "ExternalLogins": true,
+    "EmailConfirmation": true
+  },
   "Authentication": {
     "Google": {
       "ClientId": "",

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerExternalLoginTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerExternalLoginTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using AspNetCoreMvcTemplate.Emailing.Abstractions;
 using AspNetCoreMvcTemplate.Web.Controllers;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.ViewModels.Account;
 using Microsoft.AspNetCore.Http;
@@ -196,10 +197,14 @@ public class AccountControllerExternalLoginTests
         SignInManager<ApplicationUser> signInManager,
         IEmailSender emailSender)
     {
+        var featureManager = new Mock<IFeatureManager>();
+        featureManager.Setup(x => x.IsEnabled(It.IsAny<string>())).Returns(true);
+
         var controller = new AccountController(
             userManager,
             signInManager,
             emailSender,
+            featureManager.Object,
             NullLogger<AccountController>.Instance);
 
         // URL helper e potreben za Url.Action i Url.IsLocalUrl vo actionite.

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Controllers/AccountControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using AspNetCoreMvcTemplate.Emailing.Abstractions;
 using AspNetCoreMvcTemplate.Web.Controllers;
+using AspNetCoreMvcTemplate.Web.Features;
 using AspNetCoreMvcTemplate.Web.Models.Identity;
 using AspNetCoreMvcTemplate.Web.ViewModels.Account;
 using Microsoft.AspNetCore.Http;
@@ -254,10 +255,16 @@ public class AccountControllerTests
         SignInManager<ApplicationUser> signInManager,
         IEmailSender emailSender)
     {
+        // Default: site features se vkluceni - tako site postojni testovi
+        // se odnesuvaat kako i pred dodavanjeto na feature toggles.
+        var featureManager = new Mock<IFeatureManager>();
+        featureManager.Setup(x => x.IsEnabled(It.IsAny<string>())).Returns(true);
+
         return new AccountController(
             userManager,
             signInManager,
             emailSender,
+            featureManager.Object,
             NullLogger<AccountController>.Instance);
     }
 

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureGateAttributeTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureGateAttributeTests.cs
@@ -41,16 +41,15 @@ public class FeatureGateAttributeTests
     }
 
     [Fact]
-    public void OnAuthorization_Returns404_WhenFeatureManagerIsNotRegistered()
+    public void OnAuthorization_Throws_WhenFeatureManagerIsNotRegistered()
     {
-        // Edge case: ako nekoj zaboravi da go registrira IFeatureManager-ot,
-        // pobezbedno e da blokirame request-ot otkolku da pretpostavime "vkluceno".
+        // Misskonfiguracija (zaboraven AddFeatureManagement() call) treba glasno
+        // da se manifestira preku exception, a ne da se prikrie kako 404.
+        // 404 bi izgledalo identicno so "feature isklucena" - loso za debug.
         var context = CreateContext(featureManager: null);
         var filter = new FeatureGateAttribute("AdminArea");
 
-        filter.OnAuthorization(context);
-
-        Assert.IsType<NotFoundResult>(context.Result);
+        Assert.Throws<InvalidOperationException>(() => filter.OnAuthorization(context));
     }
 
     private static AuthorizationFilterContext CreateContext(IFeatureManager? featureManager)

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureGateAttributeTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureGateAttributeTests.cs
@@ -1,0 +1,76 @@
+using AspNetCoreMvcTemplate.Web.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Features;
+
+public class FeatureGateAttributeTests
+{
+    [Fact]
+    public void OnAuthorization_Returns404_WhenFeatureIsDisabled()
+    {
+        var featureManager = new Mock<IFeatureManager>();
+        featureManager.Setup(x => x.IsEnabled("AdminArea")).Returns(false);
+
+        var context = CreateContext(featureManager.Object);
+        var filter = new FeatureGateAttribute("AdminArea");
+
+        filter.OnAuthorization(context);
+
+        Assert.IsType<NotFoundResult>(context.Result);
+    }
+
+    [Fact]
+    public void OnAuthorization_AllowsRequest_WhenFeatureIsEnabled()
+    {
+        var featureManager = new Mock<IFeatureManager>();
+        featureManager.Setup(x => x.IsEnabled("AdminArea")).Returns(true);
+
+        var context = CreateContext(featureManager.Object);
+        var filter = new FeatureGateAttribute("AdminArea");
+
+        filter.OnAuthorization(context);
+
+        // context.Result ostanuva null koga filter-ot ne short-circuit-uva.
+        Assert.Null(context.Result);
+    }
+
+    [Fact]
+    public void OnAuthorization_Returns404_WhenFeatureManagerIsNotRegistered()
+    {
+        // Edge case: ako nekoj zaboravi da go registrira IFeatureManager-ot,
+        // pobezbedno e da blokirame request-ot otkolku da pretpostavime "vkluceno".
+        var context = CreateContext(featureManager: null);
+        var filter = new FeatureGateAttribute("AdminArea");
+
+        filter.OnAuthorization(context);
+
+        Assert.IsType<NotFoundResult>(context.Result);
+    }
+
+    private static AuthorizationFilterContext CreateContext(IFeatureManager? featureManager)
+    {
+        var services = new ServiceCollection();
+        if (featureManager is not null)
+        {
+            services.AddSingleton(featureManager);
+        }
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        var actionContext = new ActionContext(
+            httpContext,
+            new RouteData(),
+            new ActionDescriptor());
+
+        return new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureManagerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureManagerTests.cs
@@ -40,6 +40,20 @@ public class FeatureManagerTests
     }
 
     [Fact]
+    public void IsEnabled_IsCaseInsensitive()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions
+        {
+            AdminArea = true
+        });
+        var manager = new FeatureManager(options);
+
+        Assert.True(manager.IsEnabled("adminarea"));
+        Assert.True(manager.IsEnabled("ADMINAREA"));
+        Assert.True(manager.IsEnabled("AdMiNaReA"));
+    }
+
+    [Fact]
     public void IsEnabled_ReturnsFalse_WhenFeatureNameIsEmpty()
     {
         var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions());

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureManagerTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Features/FeatureManagerTests.cs
@@ -1,0 +1,50 @@
+using AspNetCoreMvcTemplate.Web.Features;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Features;
+
+public class FeatureManagerTests
+{
+    [Fact]
+    public void IsEnabled_ReturnsTrue_WhenFeatureFlagIsTrue()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions
+        {
+            AdminArea = true
+        });
+        var manager = new FeatureManager(options);
+
+        Assert.True(manager.IsEnabled(nameof(FeatureOptions.AdminArea)));
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenFeatureFlagIsFalse()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions
+        {
+            ProfileManagement = false
+        });
+        var manager = new FeatureManager(options);
+
+        Assert.False(manager.IsEnabled(nameof(FeatureOptions.ProfileManagement)));
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenFeatureNameDoesNotExist()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions());
+        var manager = new FeatureManager(options);
+
+        // Nepoznata feature == isklucena. Bezbedna default vrednost.
+        Assert.False(manager.IsEnabled("NonExistentFeature"));
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenFeatureNameIsEmpty()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new FeatureOptions());
+        var manager = new FeatureManager(options);
+
+        Assert.False(manager.IsEnabled(string.Empty));
+    }
+}


### PR DESCRIPTION
This PR adds a lightweight feature toggle system for enabling or disabling optional application capabilities through configuration.

The feature system is designed for template reuse and allows applications created from this starter to selectively enable or disable major capabilities without code changes.

Feature toggles are enforced in three layers:

configuration
MVC request pipeline
UI rendering / controller behavior
What’s included
Feature infrastructure
Added FeatureOptions for strongly typed feature configuration
Added IFeatureManager abstraction
Added FeatureManager implementation for runtime feature checks
Added AddFeatureManagement() service registration extension
Added FeatureGateAttribute for reusable MVC feature gating
Feature configuration

Added Features section to appsettings.json:

AdminArea
ProfileManagement
Registration
ExternalLogins
EmailConfirmation