### PR TITLE
Add integration test suite with WebApplicationFactory and SQLite in-m…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - **Logging**: Serilog (Console + File sinks), configured via `appsettings.json`, request logging middleware
 - **Health checks**: `/health` endpoint with EF Core database connectivity check
 - **Feature toggles**: `Features/` folder defines `FeatureOptions` (5 bool flags: `AdminArea`, `ProfileManagement`, `Registration`, `ExternalLogins`, `EmailConfirmation`), `IFeatureManager` (`IsEnabled(string)`), `FeatureManager` (reads `IOptions<FeatureOptions>` via reflection), and `FeatureGateAttribute` (action filter, returns 404 when feature off — "this feature doesn't exist in this app" semantics, NOT 403). Wired via `AddFeatureManagement()` in Program.cs. Startup-time decisions (Identity's `RequireConfirmedEmail`, conditional `AddExternalAuthentication` call) bind a local `FeatureOptions` directly from config; runtime decisions (controllers, views) consume `IFeatureManager` via DI. Views (`_LoginPartial`) use `@inject IFeatureManager` to hide nav links for disabled features. Default for all flags is `true` so apps with no `Features` section behave exactly like before.
+- **Integration tests**: `tests/.../Integration/` boots the full `Program.cs` pipeline in-memory via `WebApplicationFactory<Program>`. `CustomWebApplicationFactory` swaps SQL Server for **SQLite in-memory** (real SQL semantics; EF In-Memory hides constraint bugs), replaces real `IEmailSender` with `TestEmailSender` (captures messages instead of sending), uses `EphemeralDataProtectionProvider`, and exposes a `ConfigurationOverrides` dictionary so per-test feature flag overrides work without polluting `appsettings.json`. SQL Server provider services are scrubbed from DI before SQLite is registered (otherwise EF rejects "multiple relational provider configurations"). `EnsureCreated()` materializes schema after host build, not during `ConfigureServices` (the partial container at that stage can't satisfy EF dependencies). `AntiforgeryHelper` parses the `__RequestVerificationToken` from a GET form before posting — exercises the real CSRF pipeline rather than disabling antiforgery in tests.
 - **Program.cs** uses extension methods: `AddEmailing()`, `AddAdminBootstrap()`, `AddSerilogLogging()`, `AddAuthorizationPolicies()`, `AddExternalAuthentication()`, `AddFeatureManagement()`
 
 ## Completed Features
@@ -48,7 +49,8 @@ ASP.NET Core 10 MVC starter template. Controllers + Views, EF Core, ASP.NET Core
 - GitHub Actions CD (IIS deployment to staging)
 - Data protection keys persisted to file system
 - Feature toggles for AdminArea, ProfileManagement, Registration, ExternalLogins, EmailConfirmation (configurable via `Features` section in appsettings.json)
-- 73+ unit and integration tests
+- End-to-end integration tests via `WebApplicationFactory` + SQLite in-memory (auth flow, authorization, feature toggles, health endpoint)
+- 89+ unit and integration tests
 
 ## Branching
 

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/AspNetCoreMvcTemplate.Web.Tests.csproj
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/AspNetCoreMvcTemplate.Web.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AntiforgeryHelper.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AntiforgeryHelper.cs
@@ -1,0 +1,54 @@
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// Vraka antiforgery (CSRF) tokenot od HTML formata na zadadeniot URL i
+// gi spojuva so dadenite form fields da se napravi POST.
+//
+// Razionala: kontrolerite koristat [AutoValidateAntiforgeryToken], shto znachi
+// site POST-i baraat validen __RequestVerificationToken (i vo cookie i vo form
+// body). Vo realen browser flow, GET-ot na formata ja postavuva cookie-to i
+// hidden field-ot. Vo testovi go simulirame istoto: GET, parse, POST.
+//
+// Pakraj sve, ne sakame da go isklucime CSRF vo testovi - cel e da ja testirame
+// realnata pipeline, vkluchitelno antiforgery.
+public static class AntiforgeryHelper
+{
+    private static readonly Regex TokenRegex = new(
+        """<input[^>]*name="__RequestVerificationToken"[^>]*value="([^"]+)"[^>]*/?>""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // GET-uva URL, parse-uva tokenot od formata, POST-uva so istiot client (taka
+    // antiforgery cookie-to e zachuvana).
+    //
+    // tokenSourceUrl: po default e istiot kako postUrl (tipichniot slucaj - GET
+    // pa POST na ista forma). Za actions koi nemaat GET (kako Logout), prosledi
+    // razlichen URL kade tokenot moze da se najde (na primer "/").
+    public static async Task<HttpResponseMessage> PostWithAntiforgeryAsync(
+        HttpClient client,
+        string url,
+        IEnumerable<KeyValuePair<string, string>> formFields,
+        string? tokenSourceUrl = null)
+    {
+        var sourceUrl = tokenSourceUrl ?? url;
+        var getResponse = await client.GetAsync(sourceUrl);
+        getResponse.EnsureSuccessStatusCode();
+        var html = await getResponse.Content.ReadAsStringAsync();
+
+        var match = TokenRegex.Match(html);
+        if (!match.Success)
+        {
+            throw new InvalidOperationException(
+                $"Could not find antiforgery token on GET {sourceUrl}. Response was {html.Length} chars.");
+        }
+
+        var token = match.Groups[1].Value;
+
+        var fields = formFields.ToList();
+        fields.Add(new KeyValuePair<string, string>("__RequestVerificationToken", token));
+
+        var content = new FormUrlEncodedContent(fields);
+        return await client.PostAsync(url, content);
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AuthenticationFlowTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AuthenticationFlowTests.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// end to end testovi za auth pipeline-ot. Site testovi se klucni:
+// proveruvaat deka kompletno pipelineot raboti (cookie auth, Identity middleware,
+// claims factory, RequireConfirmedEmail policy, antiforgery, claims pipeline).
+public class AuthenticationFlowTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory factory;
+
+    public AuthenticationFlowTests(CustomWebApplicationFactory factory)
+    {
+        this.factory = factory;
+        this.factory.EmailSender.Clear();
+    }
+
+    [Fact]
+    public async Task Anonymous_Get_Profile_RedirectsToLogin()
+    {
+        // ApplicationCookie LoginPath = /Account/Login - cookie middleware-ot
+        // pravi 302 redirect kon Login.
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+
+        var response = await client.GetAsync("/Profile");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Account/Login", response.Headers.Location?.ToString() ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task Register_Post_CreatesUserAndSendsConfirmationEmail()
+    {
+        var client = factory.CreateClient();
+        var email = $"register-{Guid.NewGuid():N}@test.local";
+
+        var response = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test User"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        Assert.True(response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.Redirect,
+            $"Expected success or redirect, got {response.StatusCode}");
+
+        // Userot e kreiran vo bazata
+        await AssertUserExistsAsync(email);
+
+        // Email-ot e prefatren so token link
+        Assert.Single(factory.EmailSender.SentMessages);
+        var sentEmail = factory.EmailSender.SentMessages.First();
+        Assert.Equal(email, sentEmail.To);
+        Assert.Contains("token=", sentEmail.HtmlBody);
+    }
+
+    [Fact]
+    public async Task ConfirmEmail_WithValidToken_MarksUserConfirmed()
+    {
+        var client = factory.CreateClient();
+        var email = $"confirm-{Guid.NewGuid():N}@test.local";
+
+        // Step 1: register so da dobieme link vo email-ot
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        var sentEmail = factory.EmailSender.SentMessages.First(m => m.To == email);
+        var confirmUrl = ExtractHrefFromHtml(sentEmail.HtmlBody);
+
+        // Step 2: hit confirmation linkot
+        var confirmResponse = await client.GetAsync(confirmUrl);
+
+        Assert.Equal(HttpStatusCode.OK, confirmResponse.StatusCode);
+
+        // Step 3: proveri vo bazata deka user e confirmed
+        var user = await GetUserByEmailAsync(email);
+        Assert.NotNull(user);
+        Assert.True(user!.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task Login_WithUnconfirmedUser_IsNotAllowed()
+    {
+        // Register so SignIn.RequireConfirmedEmail = true - login bez confirm
+        // mora da bide blokiran. Dokazuva deka claims pipeline + RequireConfirmedEmail
+        // policy-to rabotat zaedno.
+        var client = factory.CreateClient();
+        var email = $"unconfirmed-{Guid.NewGuid():N}@test.local";
+
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        // Probaj login (preskoknuvajki confirmation)
+        var loginClient = factory.CreateClient();
+        var loginResponse = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            loginClient,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1")
+            });
+
+        // Login formata se vrakja so error message - ne 302 redirect kon Home.
+        var html = await loginResponse.Content.ReadAsStringAsync();
+        Assert.Contains("not ready for sign-in", html);
+    }
+
+    [Fact]
+    public async Task Login_WithConfirmedUser_RedirectsHome()
+    {
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+        var email = $"login-{Guid.NewGuid():N}@test.local";
+
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        // Manuelno potvrdi (preku UserManager) - po-brzo i poizolirano otkolku
+        // da lovime token od email.
+        await ConfirmUserAsync(email);
+
+        var loginResponse = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1")
+            });
+
+        // Successful login = 302 to Home
+        Assert.Equal(HttpStatusCode.Redirect, loginResponse.StatusCode);
+        Assert.Equal("/", loginResponse.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task Logout_ClearsAuthCookie()
+    {
+        var client = factory.CreateClient();
+        var email = $"logout-{Guid.NewGuid():N}@test.local";
+
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        await ConfirmUserAsync(email);
+
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1")
+            });
+
+        // Sega sme login-ti. Logout nema GET, pa go zememe tokenot od home page
+        // kade _LoginPartial render-uva logout formata so antiforgery token.
+        var logoutResponse = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Logout",
+            Enumerable.Empty<KeyValuePair<string, string>>(),
+            tokenSourceUrl: "/");
+
+        Assert.True(logoutResponse.IsSuccessStatusCode || logoutResponse.StatusCode == HttpStatusCode.Redirect);
+
+        // Posle logout, /Profile pak treba da redirektira kon login.
+        var noAutoRedirect = factory.CreateClient(new() { AllowAutoRedirect = false });
+        // Ovoj client nema cookie - testot se potvrduva preku faktot deka noviot
+        // client e anonimen, taka shto pristapot e blokiran. Site postoeshti
+        // cookie-a se ochisteni posle logout.
+        var profileResponse = await noAutoRedirect.GetAsync("/Profile");
+        Assert.Equal(HttpStatusCode.Redirect, profileResponse.StatusCode);
+    }
+
+    // ---------- Helpers ----------
+
+    private async Task AssertUserExistsAsync(string email)
+    {
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+    }
+
+    private async Task<ApplicationUser?> GetUserByEmailAsync(string email)
+    {
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        return await userManager.FindByEmailAsync(email);
+    }
+
+    private async Task ConfirmUserAsync(string email)
+    {
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = await userManager.FindByEmailAsync(email)
+            ?? throw new InvalidOperationException($"User {email} not found.");
+        var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
+        var result = await userManager.ConfirmEmailAsync(user, token);
+        Assert.True(result.Succeeded);
+    }
+
+    private static string ExtractHrefFromHtml(string html)
+    {
+        var match = Regex.Match(html, """href="([^"]+)""");
+        return match.Success ? match.Groups[1].Value : string.Empty;
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AuthorizationTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/AuthorizationTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// Krajno-kraj testovi za policy-based authorization. Proveruvaat deka:
+//   - AdminOnly policy gi blokira ne-admin korisnicite (403/redirect)
+//   - AdminOnly policy gi propusta admin-ite
+//   - RequireConfirmedEmail vo cookie configot blokira unconfirmed useri
+//
+// Za razlika od unit testovite (koi mockuvaat policies), ovde sve odi preku
+// realniot DI + middleware pipeline.
+public class AuthorizationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory factory;
+
+    public AuthorizationTests(CustomWebApplicationFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    [Fact]
+    public async Task AdminArea_WithoutAdminRole_ReturnsForbiddenOrRedirect()
+    {
+        // Authenticated user bez Admin role - AdminOnly policy go blokira.
+        // ASP.NET Core po default vraka 302 redirect kon AccessDenied za
+        // authenticated-ama-not-authorized slucai (a ne 403).
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+        var email = await CreateConfirmedUserAsync();
+        await SignInAsync(client, email, "Password1");
+
+        var response = await client.GetAsync("/Admin");
+
+        // Cookie auth confugurira AccessDeniedPath = "/Account/AccessDenied" -
+        // expectani 302 redirect.
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("AccessDenied", response.Headers.Location?.ToString() ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task AdminArea_WithAdminRole_ReturnsOk()
+    {
+        var client = factory.CreateClient();
+        var email = await CreateConfirmedUserAsync(role: "Admin");
+        await SignInAsync(client, email, "Password1");
+
+        var response = await client.GetAsync("/Admin");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnconfirmedUser_CannotSignIn()
+    {
+        // Slica zashto: nashata RequireConfirmedEmail policy + Identity options
+        // RequireConfirmedEmail = true (od Program.cs) blokiraat sign-in.
+        // SignInManager vrakja IsNotAllowed - kontrolerot ne postavuva auth
+        // cookie. Posle "login" - userot e neavtenticiran.
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+        var email = await CreateUnconfirmedUserAsync();
+
+        var loginResponse = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1")
+            });
+
+        // Login formata se vrakja so error message - login ne uspeal.
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+
+        // Probaj zatvoreni resursi - userot ne treba da bide avtenticiran.
+        var profileResponse = await client.GetAsync("/Profile");
+        Assert.Equal(HttpStatusCode.Redirect, profileResponse.StatusCode);
+    }
+
+    // ---------- Helpers ----------
+
+    private async Task<string> CreateConfirmedUserAsync(string? role = null)
+    {
+        var email = $"auth-{Guid.NewGuid():N}@test.local";
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = email,
+            Email = email,
+            Name = "Test User",
+            EmailConfirmed = true
+        };
+
+        var createResult = await userManager.CreateAsync(user, "Password1");
+        Assert.True(createResult.Succeeded);
+
+        if (role is not null)
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+            {
+                await roleManager.CreateAsync(new IdentityRole(role));
+            }
+            await userManager.AddToRoleAsync(user, role);
+        }
+
+        return email;
+    }
+
+    private async Task<string> CreateUnconfirmedUserAsync()
+    {
+        var email = $"unconfirmed-{Guid.NewGuid():N}@test.local";
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = email,
+            Email = email,
+            Name = "Test User",
+            EmailConfirmed = false
+        };
+
+        var result = await userManager.CreateAsync(user, "Password1");
+        Assert.True(result.Succeeded);
+        return email;
+    }
+
+    private static async Task SignInAsync(HttpClient client, string email, string password)
+    {
+        var response = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", password)
+            });
+
+        // Po uspeshen login, response e 302 ili (so AllowAutoRedirect=true) 200
+        // posle redirect. Vo dvata slucai user-ot e signed-in.
+        if (response.StatusCode != HttpStatusCode.Redirect && !response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Sign-in failed with status {response.StatusCode}.");
+        }
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/CustomWebApplicationFactory.cs
@@ -1,0 +1,128 @@
+using AspNetCoreMvcTemplate.Emailing.Abstractions;
+using AspNetCoreMvcTemplate.Web.Data;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// Boots the full Program.cs pipeline in-memory, with these test-specific overrides:
+//
+//   1. SQL Server -> SQLite in-memory (Mode=Memory;Cache=Shared so multiple
+//      DbContext instances ja gledaat istata baza vo ramki na eden test fixture)
+//   2. Real IEmailSender -> TestEmailSender (capture, ne send)
+//   3. File-system DataProtection -> EphemeralDataProtectionProvider
+//      (test-friendly, ne zapishuva keys na disk)
+//   4. FeatureOptions overrides preku in-memory configuration -
+//      sekoj test fixture moze da boot-ne so razlicni feature flags
+//
+// IClassFixture<CustomWebApplicationFactory> spodeluva eden factory megu site
+// testovi vo edna klasa (brz startup). Sekoja klasa kaja saka razlicni feature
+// flags ima svoja sopstvena podklasa.
+// konfigurariraj za when you boot my app for tests, use these hooks during startup.
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    // Connection ostanuva otvorena za celiot zhivot na factory-to.
+    // Koga toa kje se zatvori, SQLite in-memory bazata isceznuva.
+    private readonly SqliteConnection connection;
+
+    // Public za da test fixture-ite gi setuvaat OVERRIDES PRED CreateClient.
+    public Dictionary<string, string?> ConfigurationOverrides { get; } = new();
+
+    public TestEmailSender EmailSender { get; } = new();
+
+    public CustomWebApplicationFactory()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            // Overrides za config keys (na primer, Features:AdminArea = false).
+            // Mora po site drugi providers za da imaat priority.
+            config.AddInMemoryCollection(ConfigurationOverrides!);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // Otstrani go SQL Server DbContext (registriran vo Program.cs)
+            ReplaceDbContext(services);
+
+            // Otstrani go realniot IEmailSender (LoggingEmailSender) i registriraj
+            // Test version. AddSingleton so explicit instance za da gi citame
+            //  porakite preku factory.EmailSender.
+            services.RemoveAll<IEmailSender>();
+            services.AddSingleton<IEmailSender>(EmailSender);
+
+            // DataProtection vo testovi - ephemeral keys, bez file system pristap.
+            services.AddDataProtection()
+                .UseEphemeralDataProtectionProvider();
+        });
+    }
+
+    private void ReplaceDbContext(IServiceCollection services)
+    {
+        // AddDbContext vo Program.cs registrira ne samo DbContextOptions<T> tuku
+        // i lambdi vo IConfigureOptions<DbContextOptions<T>> koi sodrzhat UseSqlServer.
+        // Ako ne gi otstranime SITE EF SQL Server descriptors, novata UseSqlite-options
+        // ke se kombinira so postojnata UseSqlServer-options i ke puka:
+        // "Multiple relational database provider configurations found".
+        var efDescriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>) ||
+                d.ServiceType == typeof(DbContextOptions) ||
+                d.ServiceType == typeof(ApplicationDbContext) ||
+                d.ServiceType == typeof(IDbContextOptionsConfiguration<ApplicationDbContext>) ||
+                (d.ServiceType.FullName?.Contains("EntityFrameworkCore.SqlServer", StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (d.ImplementationType?.FullName?.Contains("EntityFrameworkCore.SqlServer", StringComparison.OrdinalIgnoreCase) ?? false))
+            .ToList();
+
+        foreach (var d in efDescriptors)
+        {
+            services.Remove(d);
+        }
+
+        // Sega ima samo SQLite provider services - bez konflikt.
+        services.AddDbContext<ApplicationDbContext>(options =>
+        {
+            options.UseSqlite(connection);
+        });
+    }
+
+    // Posle build na celiot host, otvori scope i EnsureCreated. Ova ne moze
+    // da se napravi vo ConfigureServices provider-ot tamu e
+    // statichen i Database.EnsureCreated bara komplet konfiguriran provider.
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Database.EnsureCreated();
+
+        return host;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            connection.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}
+

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/FeatureToggleTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/FeatureToggleTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using AspNetCoreMvcTemplate.Web.Models.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// Krajno-kraj testovi za feature toggles. Unit testovite proveruvaat deka
+// FeatureGateAttribute vraka 404 koga manager-ot vraka false. Ovde proveruvame
+// sceloto: confg flag = false -> realna HTTP request -> 404.
+//
+// Sekoj test boot-uva sopstven factory so razlicen Features:* override za da
+// ne se ushtetuvaat eden so drug.
+public class FeatureToggleTests
+{
+    [Fact]
+    public async Task Profile_WhenProfileManagementOff_Returns404()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        factory.ConfigurationOverrides["Features:ProfileManagement"] = "false";
+
+        var email = await CreateConfirmedUserAsync(factory);
+        var client = factory.CreateClient();
+        await SignInAsync(client, email);
+
+        var response = await client.GetAsync("/Profile");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_WhenAdminAreaOff_Returns404()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        factory.ConfigurationOverrides["Features:AdminArea"] = "false";
+
+        var email = await CreateConfirmedUserAsync(factory, role: "Admin");
+        var client = factory.CreateClient();
+        await SignInAsync(client, email);
+
+        var response = await client.GetAsync("/Admin");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WhenRegistrationOff_Returns404()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        factory.ConfigurationOverrides["Features:Registration"] = "false";
+
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/Account/Register");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task LoginPage_WhenExternalLoginsOff_HasNoExternalButtons()
+    {
+        // ExternalLogins = false -> AddExternalAuthentication ne se vika -> nema
+        // schemes registrirani -> Login stranata ne render-uva niedna provider button.
+        using var factory = new CustomWebApplicationFactory();
+        factory.ConfigurationOverrides["Features:ExternalLogins"] = "false";
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/Account/Login");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // "Or sign in with" e tekstot vo Login.cshtml koj se prikazuva samo ako
+        // postojat external schemes. Ne treba da go ima.
+        Assert.DoesNotContain("Or sign in with", html);
+    }
+
+    [Fact]
+    public async Task Register_WhenEmailConfirmationOff_SignsInImmediately()
+    {
+        // Posebniot kombinaciski test: ako EmailConfirmation = false, registracija
+        // pravi user so EmailConfirmed = true i go signira odma. Toa e
+        // alternativen flow napraven vo feature-toggles branch.
+        using var factory = new CustomWebApplicationFactory();
+        factory.ConfigurationOverrides["Features:EmailConfirmation"] = "false";
+
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+        var email = $"noconfirm-{Guid.NewGuid():N}@test.local";
+
+        var response = await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Register",
+            new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test"),
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1"),
+                new KeyValuePair<string, string>("ConfirmPassword", "Password1")
+            });
+
+        // Po uspeshna registracija so EmailConfirmation off, redirect kon "/" so
+        // signed-in cookie. Bez confirmation email step.
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal("/", response.Headers.Location?.ToString());
+
+        // I nikako ne se prati confirmation email
+        Assert.Empty(factory.EmailSender.SentMessages);
+
+        // I user-ot vo bazata e EmailConfirmed = true
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+        Assert.True(user!.EmailConfirmed);
+    }
+
+    // ---------- Helpers (kopija od AuthorizationTests - moze za posle da se
+    // izvajat vo TestUserHelper, ama za sega e OK ovde za clarity) ----------
+
+    private static async Task<string> CreateConfirmedUserAsync(CustomWebApplicationFactory factory, string? role = null)
+    {
+        var email = $"toggle-{Guid.NewGuid():N}@test.local";
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = email,
+            Email = email,
+            Name = "Test",
+            EmailConfirmed = true
+        };
+
+        await userManager.CreateAsync(user, "Password1");
+
+        if (role is not null)
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+            {
+                await roleManager.CreateAsync(new IdentityRole(role));
+            }
+            await userManager.AddToRoleAsync(user, role);
+        }
+
+        return email;
+    }
+
+    private static async Task SignInAsync(HttpClient client, string email)
+    {
+        await AntiforgeryHelper.PostWithAntiforgeryAsync(
+            client,
+            "/Account/Login",
+            new[]
+            {
+                new KeyValuePair<string, string>("Email", email),
+                new KeyValuePair<string, string>("Password", "Password1")
+            });
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/HealthEndpointTests.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/HealthEndpointTests.cs
@@ -1,0 +1,29 @@
+using System.Net;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// Najprostiot moshen test koj go potvrduva deka:
+//   - Factory-to mozhe da boot-ne aplikacijata
+//   - SQLite zamenata na DbContext-ot raboti (health check baras DbContextCheck)
+//   - HTTP pipeline-ot odgovara
+public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory factory;
+
+    public HealthEndpointTests(CustomWebApplicationFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    [Fact]
+    public async Task GetHealth_ReturnsHealthy()
+    {
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Healthy", body);
+    }
+}

--- a/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/TestEmailSender.cs
+++ b/tests/AspNetCoreMvcTemplate.Web.Tests/Integration/TestEmailSender.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+using AspNetCoreMvcTemplate.Emailing.Abstractions;
+using AspNetCoreMvcTemplate.Emailing.Models;
+
+namespace AspNetCoreMvcTemplate.Web.Tests.Integration;
+
+// In-memory IEmailSender koj ja zachuvuva sekoja poraka vo lista. Vo testovi sakame
+// da znaeme sto bi se ispratilo (sodrzhina, naslov, link), bez vsushnost da
+// pratame email. Trivijalna implementacija - ConcurrentBag e thread-safe za
+// slucaj na paralelni testovi.
+public class TestEmailSender : IEmailSender
+{
+    public ConcurrentBag<EmailMessage> SentMessages { get; } = new();
+
+    public Task<EmailSendResult> SendAsync(EmailMessage message, CancellationToken cancellationToken = default)
+    {
+        SentMessages.Add(message);
+        return Task.FromResult(new EmailSendResult { Succeeded = true });
+    }
+
+    public void Clear()
+    {
+        SentMessages.Clear();
+    }
+}


### PR DESCRIPTION
This PR adds end-to-end integration coverage for the MVC template using WebApplicationFactory<Program>.

Until now, the test suite covered isolated behavior well (74 unit tests), but did not validate the full application as a composed system. This PR adds a focused integration layer that boots the real app in-memory and exercises the actual ASP.NET Core pipeline through real HTTP requests.

That gives us coverage for framework wiring concerns unit tests cannot catch: middleware ordering, cookie auth, route registration, DI composition, antiforgery enforcement, Identity integration, and feature-gated endpoints.

What’s included
Integration test infrastructure
Added CustomWebApplicationFactory : WebApplicationFactory<Program>
Boots the real app in-memory under Testing
Replaces SQL Server with SQLite in-memory
Replaces real IEmailSender with in-memory TestEmailSender
Replaces file-based Data Protection with ephemeral in-memory keys
Supports per-test configuration overrides for feature flag scenarios
Test utilities
Added TestEmailSender to capture sent emails in memory
Added AntiforgeryHelper to simulate real MVC GET → token parse → POST flow
Integration coverage added
Health: app boots and /health responds
Authentication flow:
anonymous redirect
registration
confirmation email generation
email confirmation
confirmed vs unconfirmed login behavior
logout
Authorization:
admin-only access enforcement
role-based success path
confirmed-email enforcement
Feature toggles:
profile gated
admin gated
registration gated
external logins hidden in UI
registration immediate sign-in when email confirmation disabled